### PR TITLE
Syncing changes from local draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,6 @@ foo.com - Site requiring a Trust Token to prove the user is trusted.
 ```
 
 
-
 1.  User visits `areyouahuman.com`.
 1.  `areyouahuman.com` verifies the user is a human, and calls `fetchTrustTokens('/request-tokens')`.
     1.  The browser stores the trust tokens associated with `areyouahuman.com`.


### PR DESCRIPTION
Syncing some changes from a local draft:
- a few minor cleanups (in particular, Charlie wanted the brackets around variable names changed to carets after a reader thought the brackets denoted repeated fields)
- clarify meaning of SRR expiry (viz., an expired SRR is treated as if it doesn't exist)
- move the signed-request timestamp into the signing data
- expand the context of the "cross-site information transfer" section slightly
- clarify that number-of-issuers limits apply to issuance from frames, too

My WICG membership is pending; if it matters, I can leave another comment once it's been confirmed by Google's WICG Advisory Committee Representative.