### PR TITLE
Update the request signing data example

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,8 @@ If `signRequestData` is `include`, then the browser will sign over the request d
 
 ```
 {
-  'url': 'https://example.test/subresource',
+  'destination': 'example.test',
   'sec-signed-redemption-record': <SRR>,
-  'referer': 'https://example.test/',
   'sec-time': <high-resolution client timestamp>
   'public-key': <pk>,
 }


### PR DESCRIPTION
This change:
- renames the "url" field to "destination" in line with recent changes
- removes the "referer" header from the example as this is one of the headers that it will likely be difficult to sign over (can change on redirects)