### PR TITLE
Add discussion of non-web sources of tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@ A possible enhancement would be to allow for sending Signed Redemption Records (
 
 If the publisher can configure issuers in response headers (or otherwise early in the page load), then they could invoke a redemption in parallel with the page loading, before the relevant `fetch()` calls.
 
+### Non-web sources of tokens
+
+Trust token issuance could be expanded to other entities (the operating system, or native applications) capable of making an informed decision about whether to grant tokens. Naturally, this would need to take into consideration different systems' security models in order for these tokens to maintain their meaning. (For instance, on some platforms, malicious applications might routinely have similar privileges to the operating system itself, which would at best reduce the signal-to-noise ratio of tokens created by the operating system.)
 
 ## Appendix
 


### PR DESCRIPTION
This change expands the Future Extensions section to discuss the possibility of obtaining tokens from non-web sources like native applications or operating systems.