### PR TITLE
Add alg field to support crypto agility for Request Signing extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The browser will add a new request header with the resulting signature over a co
 
 ```
 Sec-Signature:
+  alg=<alg>
   public-key=<pk>
   sig=<signature>
   sign-request-data=<include, headers-only>


### PR DESCRIPTION
As mentioned in [#45](https://github.com/WICG/trust-token-api/issues/45#issuecomment-707792652), to support crypto agility for the Request Signing extension we need to provide the algorithm identifier for the algorithm used to sign the request.