### PR TITLE
Add Signing Algorithm as field in Redemption Record sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ Different issuers/ecosystems should specify their own Redemption Record format s
   Metadata: {
     Trust Token Key ID
   },
-  SigAlg: <Well known algorithm identifier used to sign this RR>,
   Signature of the above verifiable by well-known public key of the issuer,
+  SigAlg: <Well known algorithm identifier used to sign this RR>,
   optional expiry timestamp
 }
 ```

--- a/README.md
+++ b/README.md
@@ -351,7 +351,8 @@ Different issuers/ecosystems should specify their own Redemption Record format s
   },
   Metadata: {
     Trust Token Key ID
-  }
+  },
+  SigAlg: <Well known algorithm identifier used to sign this RR>
   Signature of the above verifiable by well-known public key of the issuer,
   optional expiry timestamp
 }

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Different issuers/ecosystems should specify their own Redemption Record format s
   Metadata: {
     Trust Token Key ID
   },
-  SigAlg: <Well known algorithm identifier used to sign this RR>
+  SigAlg: <Well known algorithm identifier used to sign this RR>,
   Signature of the above verifiable by well-known public key of the issuer,
   optional expiry timestamp
 }


### PR DESCRIPTION
Depending on how their ecosystem with RR consumers is configured, issuers may support multiple signing algorithms when signing RRs. In light of this, add a new suggested `SigAlg` field to the sample RR.