### PR TITLE
Add link for ECDSA algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Sec-Signature:
 ```
 
 
-The canonical CBOR data (verifiable by the signature) should be computable from a request, and so does not need to be sent over the wire from the browser. The `Signed-Headers` header, and the value of `sign-request-data` should be enough to re-construct it server side, robust to things like header re-ordering, etc. In Version 3 of the protocol, the algorithm used for signing is `ecdsa_secp256r1_sha256`.
+The canonical CBOR data (verifiable by the signature) should be computable from a request, and so does not need to be sent over the wire from the browser. The `Signed-Headers` header, and the value of `sign-request-data` should be enough to re-construct it server side, robust to things like header re-ordering, etc. In Version 3 of the protocol, the algorithm used for signing is [`ecdsa_secp256r1_sha256`](https://tools.ietf.org/html/rfc8446#section-4.2.3).
 
 
 ### Extension: Metadata


### PR DESCRIPTION
Missed adding a link to the signature algorithm source in the README, updating to match the ISSUER_PROTOCOL doc.