### PR TITLE
Update key commitment format.

### DIFF
--- a/ISSUER_PROTOCOL.md
+++ b/ISSUER_PROTOCOL.md
@@ -19,7 +19,7 @@ A Trust Token issuer should have an endpoint at a publicly accessible secure URL
 Key commitment result
 {
   <protocol_version>: {
-    "protocol_version": <protocol version, TrustTokenV3PMB or TrustTokenV3VOPRF for this>,
+    "protocol_version": <protocol version as a string, "TrustTokenV3PMB" or "TrustTokenV3VOPRF" for this>,
     "id": <key commitment identifier, as a monotonically increasing integer>
     "batchsize": <batch size>,
     "keys": {

--- a/ISSUER_PROTOCOL.md
+++ b/ISSUER_PROTOCOL.md
@@ -38,7 +38,8 @@ Key commitment result
 }
 ```
 
-The commitment is a dictionary keyed by protocol version where each value is a self-contained key commitment for that version. To support compatibility with prior
+The commitment is a dictionary keyed by protocol version where each value is a self-contained key commitment for that version (for
+current protocol versions, the protocol_version field is also included as a field of the individual commitment itself). To support compatibility with prior
 key commitment formats, unknown fields in the top level dictionary should be ignored. The `id` field is used as a unique identifier to identify this key commitment
 and to allow comparing the freshness of key commitments (larger values indicate a newer key commitment).
 
@@ -486,6 +487,6 @@ struct {
 
 ## Version History
 
-V3 uses [`ecdsa_secp256r1_sha256`](https://tools.ietf.org/html/rfc8446#section-4.2.3) as the signing algorithm for request signing and updates the key commitment format.
+V3 uses [`ecdsa_secp256r1_sha256`](https://tools.ietf.org/html/rfc8446#section-4.2.3) as the signing algorithm for request signing and updates the key commitment format to nest it in a version-keyed dictionary (and to move the set of keys to their own dictionary within the commitment).
 
 V2 introduces two protocol versions, each supporting a different arrangement of public and private metadata. It also enables the issuer to structure the Redemption Record as they choose, and removes the signing requirement.

--- a/ISSUER_PROTOCOL.md
+++ b/ISSUER_PROTOCOL.md
@@ -39,7 +39,7 @@ Key commitment result
 
 The commitment is a dictionary keyed by protocol version where each value is a self-contained key commitment for that version (for
 current protocol versions, the protocol_version field is also included as a field of the individual commitment itself). To support compatibility with prior
-key commitment formats, unknown fields in the top level dictionary should be ignored. The `id` field is used as a unique identifier to identify this key commitment
+key commitment formats, unknown fields in the top level dictionary should be ignored. The `id` field is used as a unique identifier to identify each key commitment
 and to allow comparing the freshness of key commitments (larger values indicate a newer key commitment).
 
 ### Issuing Tokens

--- a/ISSUER_PROTOCOL.md
+++ b/ISSUER_PROTOCOL.md
@@ -22,7 +22,6 @@ Key commitment result
     "protocol_version": <protocol version, TrustTokenV3PMB or TrustTokenV3VOPRF for this>,
     "id": <key commitment identifier, as a monotonically increasing integer>
     "batchsize": <batch size>,
-    "srrkey": <base-64 encoded SRRVerificationKey, in 32-byte RFC8032 encoding>,
     "keys": {
       <keyID>: { "Y": <base64-encoded TrustTokenPublicKey>,
                          "expiry": <key expiry, encoded as a string representation of

--- a/ISSUER_PROTOCOL.md
+++ b/ISSUER_PROTOCOL.md
@@ -18,22 +18,29 @@ A Trust Token issuer should have an endpoint at a publicly accessible secure URL
 ```
 Key commitment result
 {
-  "protocol_version": <protocol version, TrustTokenV3PMB or TrustTokenV3VOPRF for this>,
-  "id": <key commitment identifier, as a monotonically increasing integer>
-  "batchsize": <batch size>,
-  "srrkey": <base-64 encoded SRRVerificationKey, in 32-byte RFC8032 encoding>,
-  <keyID>: { "Y": <base64-encoded TrustTokenPublicKey>,
-                     "expiry": <key expiry, encoded as a string representation of
-                                an integer timestamp in microseconds since the Unix
-                                epoch> },
-  <keyID>: { "Y": <base64-encoded public key>,
-                     "expiry": <key expiry, encoded as a string representation of
-                                an integer timestamp in microseconds since the Unix
-                                epoch> }, ...
+  <protocol_version>: {
+    "protocol_version": <protocol version, TrustTokenV3PMB or TrustTokenV3VOPRF for this>,
+    "id": <key commitment identifier, as a monotonically increasing integer>
+    "batchsize": <batch size>,
+    "srrkey": <base-64 encoded SRRVerificationKey, in 32-byte RFC8032 encoding>,
+    "keys": {
+      <keyID>: { "Y": <base64-encoded TrustTokenPublicKey>,
+                         "expiry": <key expiry, encoded as a string representation of
+                                    an integer timestamp in microseconds since the Unix
+                                    epoch> },
+      <keyID>: { "Y": <base64-encoded public key>,
+                         "expiry": <key expiry, encoded as a string representation of
+                                    an integer timestamp in microseconds since the Unix
+                                    epoch> }, ...
+    }
+  },
+  ...
 }
 ```
 
-The `id` field is used as a unique identifier to identify this key commitment and to allow comparing the freshness of key commitments (larger values indicate a newer key commitment).
+The commitment is a dictionary keyed by protocol version where each value is a self-contained key commitment for that version. To support compatibility with prior
+key commitment formats, unknown fields in the top level dictionary should be ignored. The `id` field is used as a unique identifier to identify this key commitment
+and to allow comparing the freshness of key commitments (larger values indicate a newer key commitment).
 
 ### Issuing Tokens
 
@@ -479,6 +486,6 @@ struct {
 
 ## Version History
 
-V3 uses [`ecdsa_secp256r1_sha256`](https://tools.ietf.org/html/rfc8446#section-4.2.3) as the signing algorithm for request signing.
+V3 uses [`ecdsa_secp256r1_sha256`](https://tools.ietf.org/html/rfc8446#section-4.2.3) as the signing algorithm for request signing and updates the key commitment format.
 
 V2 introduces two protocol versions, each supporting a different arrangement of public and private metadata. It also enables the issuer to structure the Redemption Record as they choose, and removes the signing requirement.


### PR DESCRIPTION
This allows the key commitment endpoint to support multiple versions and moves 'keys' to be in its own dictionary/namespace.

Fixes #57 and #58.