### PR TITLE
Make batchsize limit implementation-defined.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -210,11 +210,9 @@ Requests to key commitment endpoints should result in a JSON response
 
 * `"batchsize"` specifies the maximum number of blinded tokens that the issuer
                 supports for each token issuance operation. Its value is a
-                string representation of a positive integer. Maximum value
-                allowed is 100. If a larger value is specified, 100 will be
-                used. Browser might send fewer tokens in a single operation,
-                but will generally default to sending `batchsize` many tokens
-                per operation.
+                string representation of a positive integer. Browser might send
+                fewer tokens in a single operation, but will generally default to
+                sending `batchsize` many tokens per operation.
 
 * `"keys"` field is a dictionary of public keys listed by their identifiers.
 
@@ -372,10 +370,8 @@ To <dfn>append private state token issue request headers</dfn> given a [=/reques
     Issue: This probably needs to be its own algorithm, how is "most recent" defined here?
 
  1. Let |maxSize| be |issuer|'s [=max batch size=] or the global limit of 100, whichever is smaller.
- 1. Let |numTokens| be the right number of tokens considering issuer batch size and current
-     number of tokens from the issuer.
-
-    Issue: How does one determine the right number of tokens?
+ 1. Let |numTokens| be the number of tokens to request using the minimum of an [=implementation-defined=]
+     limit on the number of tokens and the issuer's batch size.
 
  1. Let |tokens| be the result of [=generate blinded tokens|generating blinded tokens=] with |numTokens|.
  1. Configure the HTTP request.

--- a/spec.bs
+++ b/spec.bs
@@ -369,9 +369,7 @@ To <dfn>append private state token issue request headers</dfn> given a [=/reques
 
     Issue: This probably needs to be its own algorithm, how is "most recent" defined here?
 
- 1. Let |maxSize| be |issuer|'s [=max batch size=] or the global limit of 100, whichever is smaller.
- 1. Let |numTokens| be the number of tokens to request using the minimum of an [=implementation-defined=]
-     limit on the number of tokens and the |issuer|'s [=max batch size=].
+ 1. Let |numTokens| be |issuer|'s [=max batch size=] or an [=implementation-defined=] limit on the number of tokens, whichever is smaller.
 
  1. Let |tokens| be the result of [=generate blinded tokens|generating blinded tokens=] with |numTokens|.
  1. Configure the HTTP request.

--- a/spec.bs
+++ b/spec.bs
@@ -210,7 +210,7 @@ Requests to key commitment endpoints should result in a JSON response
 
 * `"batchsize"` specifies the maximum number of blinded tokens that the issuer
                 supports for each token issuance operation. Its value is a
-                string representation of a positive integer. The useragent might send
+                string representation of a positive integer. The user agent might send
                 fewer tokens in a single operation, but will generally default to
                 sending `batchsize` many tokens per operation.
 

--- a/spec.bs
+++ b/spec.bs
@@ -210,7 +210,7 @@ Requests to key commitment endpoints should result in a JSON response
 
 * `"batchsize"` specifies the maximum number of blinded tokens that the issuer
                 supports for each token issuance operation. Its value is a
-                string representation of a positive integer. Browser might send
+                string representation of a positive integer. The useragent might send
                 fewer tokens in a single operation, but will generally default to
                 sending `batchsize` many tokens per operation.
 
@@ -371,7 +371,7 @@ To <dfn>append private state token issue request headers</dfn> given a [=/reques
 
  1. Let |maxSize| be |issuer|'s [=max batch size=] or the global limit of 100, whichever is smaller.
  1. Let |numTokens| be the number of tokens to request using the minimum of an [=implementation-defined=]
-     limit on the number of tokens and the issuer's batch size.
+     limit on the number of tokens and the |issuer|'s [=max batch size=].
 
  1. Let |tokens| be the result of [=generate blinded tokens|generating blinded tokens=] with |numTokens|.
  1. Configure the HTTP request.


### PR DESCRIPTION
Fixes #153.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/pull/157.html" title="Last updated on Feb 17, 2023, 3:18 PM UTC (cd88039)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/157/5b49140...cd88039.html" title="Last updated on Feb 17, 2023, 3:18 PM UTC (cd88039)">Diff</a>