### PR TITLE
Added the PMBToken issuance and redemption protocols to spec.bs

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -61,6 +61,12 @@ urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch
         "href": "https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-07",
         "publisher": "IETF",
         "title": "Hashing to Elliptic Curves"
+    },
+    "ISSUER-PROTOCOL": {
+        "authors": ["S. Valdez", "A. Bulut", "S. Schlesinger"],
+        "href": "https://github.com/WICG/trust-token-api/blob/main/ISSUER_PROTOCOL.md",
+        "publisher": "Google",
+        "title": "ISSUER_PROTOCOL"
     }
 }
 </pre>
@@ -441,7 +447,7 @@ Sec-PST-Count: Issuing 3 tokens.
 ```
 </div>
 
-The details for servers implementing this protocol can be found in [[#crypto]].
+The details for servers implementing this protocol can be found in [[!ISSUER-PROTOCOL]].
 
 Browser Steps For Issue Response {#browser-issue-response}
 ----------------------------------------------------------
@@ -459,7 +465,7 @@ To process a response to an issue request, browser carries out the following ste
 
 Issue: Define this in terms of fetch
 
-The details for servers implementing this protocol can be found in [[#crypto]].
+The details for servers implementing this protocol can be found in [[!ISSUER-PROTOCOL]].
 
 Redeeming Tokens {#redeeming-tokens}
 ====================================
@@ -863,278 +869,6 @@ Status: standard
 Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-private-state-token-version]])
-
-Cryptographic Protocol {#crypto}
-===================================
-
-Data Serialization
-------------------------
-
-Following are the keys used for the PrivateStateTokenV3PMB protocol encoded in TLS presentation language, consisting of elliptic curve scalars and points based
-on the curve choice (P-384).
-
-```
-opaque ECPoint<1..2^16-1>; // X9.62 Uncompressed point.
-opaque Scalar<Ns>; // big-endian bytestring
-
-struct {
-  // Corresponding to the FALSE private metadata bit (x0, y0).
-  Scalar x0;
-  Scalar y0;
-  // Corresponding to the TRUE private metadata bit (x1, y1).
-  Scalar x1;
-  Scalar y1;
-  // Corresponding to the token validity (x˜, y˜).
-  Scalar xs;
-  Scalar ys;
-} TrustTokenSecretKey;
-
-struct {
-  ECPoint pub0; // Corresponding to the FALSE private metadata bit.
-  ECPoint pub1; // Corresponding to the TRUE private metadata bit.
-  ECPoint pubs; // Corresponding to the token validity check.
-} PrivateStateTokenPublicKey;
-```
-
-We use serialization schemes and hashes from draft 07 of the hash-to-curve specification, [[!HTC]].
-
-`Ht(t)` is defined as P384_XMD:SHA-512_SSWU_RO_ with a big-endian bytestring input of `t` and a dst of "PMBTokens Experiment V2 HashT".
-
-`Hs(T, s)` is defined to be P384_XMD:SHA-512_SSWU_RO_ with a bytestring input of `T` with the following content and a dst of "PMBTokens Experiment V2 HashS".
-
-```
-struct {
-  ECPoint t;
-  opaque s[Nn];
-} T;
-```
-
-The [[!HTC]] document does not define hash to scalars, so `Hc(x)` is defined to be the output of the hash_to_field function with the following parameters:
-
-* `DST` is "PMBTokens Experiment V2 HashC"
-* `F`, `p`, and `m` are defined according to the finite field `GF(r)`, where `r` is the order of P-384. Note this is a different modulus from `hash_to_field` as used in P384_XMD:SHA-512_SSWU_RO.
-* `L` is 72, derived based on P384_XMD:SHA-512_SSWU_RO_'s security parameter `k` (192), and `p` defined above.
-* `expand_message` uses the corresponding function from P384_XMD:SHA-512_SSWU_RO_.
-
-When used in the DLEQ proof, `Hc` takes the following input.
-
-```
-struct {
-  uint8 label[6] = "DLEQ2\0";
-  ECPoint X;
-  ECPoint T;
-  ECPoint S;
-  ECPoint W;
-  ECPoint K0;
-  ECPoint K1;
-} DLEQInput; // Used for DLEQ proof.
-```
-
-When used in the DLEQOR proof, `Hc` takes the following input.
-
-```
-struct {
-  uint8 label[8] = "DLEQOR2\0";
-  ECPoint X0;
-  ECPoint X1;
-  ECPoint T;
-  ECPoint S;
-  ECPoint W;
-  ECPoint K00;
-  ECPoint K01;
-  ECPoint K10;
-  ECPoint K11;
-} DLEQORInput; // Used for DLEQOR proof.
-```
-
-When used in the DLEQ batching step, `Hc` is called once for each `e_i` output, with the following input. The `index` field contains `i`.
-
-```
-struct {
-  uint8 label[11] = "DLEQ Batch\0";
-  ECPoint pubs;
-  ECPoint pub0;
-  ECPoint pub1;
-  ECPoint T'0;
-  ECPoint S'0;
-  ECPoint Wp0;
-  ECPoint Wsp0;
-  ...
-  ECPoint T'n;
-  ECPoint S'n;
-  ECPoint Wpn;
-  ECPoint Wspn;
-  uint16 index;
-} DLEQBatchInput; // Used for Batch proof.
-```
-
-The issuance request contains an `IssueRequest` structure defined below.
-
-```
-struct {
-  uint16 count;
-  ECPoint nonces[count];
-} IssueRequest;
-```
-
-The issuance response contains an `IssueResponse` structure defined below.
-
-```
-struct {
-  opaque s<Nn>; // big-endian bytestring
-  ECPoint Wp;
-  ECPoint Wsp;
-} SignedNonce;
-
-struct {
-  Scalar cs;
-  Scalar us;
-  Scalar vs;
-  Scalar c0;
-  Scalar c1;
-  Scalar u0;
-  Scalar u1;
-  Scalar v0;
-  Scalar v1;
-} DLEQProof;
-
-struct {
-  uint16 issued;
-  uint32 key_id = keyID;
-  SignedNonce signed[issued];
-  opaque proof<1..2^16-1>; // Length-prefixed form of DLEQProof.
-} IssueResponse;
-```
-
-The redemption request contains a `RedemptionRequest` structure as defined below.
-
-```
-struct {
-  uint32 key_id;
-  opaque nonce<nonce_size>;
-  ECPoint S;
-  ECPoint W;
-  ECPoint Ws;
-} Token;
-
-struct {
-  opaque token<1..2^16-1>; // Bytestring containing a serialized Token struct.
-  opaque client_data<1..2^16-1>;
-  uint64 redemption_time;
-} RedeemRequest;
-```
-
-The Private State Token redemption response contains a `RedemptionResponse` structure as defined below.
-
-```
-struct {
-  opaque rr<1..2^16-1>;
-} RedeemResponse;
-```
-
-Issuance
-------------------------
-
-The `Issue` function corresponds to the **AT.Sig** stage of the [[!PMB]] protocol. We refer to
-what is called "blinding" in [[!PMB]] as "masking".
-
-Inputs:
-
-* count (the number of tokens being requested, from the IssueRequest)
-* nonces (the list of nonces to sign)
-* secretKey (the secret key that should be used to sign this request, determined by the public metadata)
-* publicKey (the public key corresponding to the secretKey)
-* keyID (the ID corresponding to this key)
-* privateMetadata (the boolean value corresponding to the private metadata value)
-* toIssue (the number of tokens to issue)
-
-Outputs:
-
-* issued (the number of tokens being issued)
-* keyID (the key used to sign these tokens)
-* signed (the list of signed nonces)
-* cs, us, vs, c0, u0, v0, c1, u1, v1 (the list of scalars corresponding to the zero-knowledge proof)
-
-```
-Issue:
-  issued = min(count, toIssue)
-  xb,yb = secretKey.x1, secretKey.y1
-  if privateMetadata == 0:
-    xb,yb = secretKey.x0, secretKey.y0
-  signed = []
-  T,S,W,Ws = [], [], [], []
-  for i in 0..issued:
-    T' = nonces[i]
-    s ←$ {0, 1}λ
-    S' = Hs(T', s)
-    Wp = xb*T' + yb*S'
-    Wsp = secretKey.xs*T' + secretKey.ys*S'
-    T,S,W,Ws += T', S', Wp, Wsp
-    signed += SignedNonce{s, Wp, Wsp}
-  proof = DLEQbatched.P((publicKey,T,S,W,Ws),(secretKey.xs, secretKey.ys, xb, yb))
-  return (issued, keyID, signed, proof)
-
-DLEQbatched.P((X,T,S,W,Ws),(xs, ys, xb, yb)):
-  e0,...,em = Hc(X,T,S,W,Ws)
-  Tt = Sum(ej*Tj) // over j from 0 to m
-  St = Sum(ej*Sj) // over j from 0 to m
-  Wt = Sum(ej*Wj) // over j from 0 to m
-  Wst = Sum(ej*Wsj) // over j from 0 to m
-  dleqProof = DLEQ2.P((X,T,S,Ws), (xs,ys)) // cs,us,vs
-  dleqorProof = DLEQOR2.P((X,T,S,W), (xb,yb)) // c0,c1,u0,u1,v0,v1
-  return dleqProof + dleqorProof
-```
-
-`DLEQOR2.P` is specified by replacing `n = 2` in the above and `DLEQ2.P`
-is specified by replacing `n = 1` in the below procedure.
-
-```
-DLEQOR.P((X, T, S, W), (xb, yb)):
-  k0, k1 sampled uniformly from Z^2_p
-  Kb = k0 * (G; T) + k1 * (H; S)
-  for i in [n], i != b:
-    ci, ui, vi sampled uniformly from Z_p
-    K = ui * (G; T) + vi * (H; S) - ci * (Xi; W)
-  c = Hc((X, T, S, W), K0, ..., Nn)
-  cb = c - Sum(ci) // over i in [n] not equal to b
-  ub = k0 + cb * xb
-  vb = k1 + cb * yb
-  return (c, u, v)
-```
-
-Redemption
-------------------------
-
-The `Redeem` function below corresponds to the **AT.VerValid** and **AT.ReadBit** stages of the [[!PMB]] protocol.
-
-Inputs:
-
-*   token (The private state token to redeem)
-*   client\_data (the client data sent as part of the redemption request to include in the SRR)
-*   secretKey (the secret key that should be used to sign this request, determined by the public metadata)
-*   keys (dictionary from known key IDs to secret/public keys)
-
-Outputs:
-
-*   public_metadata (the ID of the keypair used to generate this token)
-*   private_metadata (the bit value of the private metadata, if aplicable)
-
-```
-Redeem:
-  secretKey, publicKey = keys[token.key_id]
-  T = Ht(token.nonce)
-  if token.Ws != secretKey.xs*T+secretKey.ys*token.S:
-    return 0 // Invalid validity verification.
-  W0 = secretKey.x0*T+secretKey.y0*token.S
-  W1 = secretKey.x1*T+secretKey.y1*token.S
-  // These equalities are timing-sensitive as they could be a timing side-channel.
-  isW0 = constantTimeEquality(tokenW, W0)
-  isW1 = constantTimeEquality(tokenW, W1)
-  if !(isW0 ^ isW1):
-    return 0 // Internal Error
-  privateMetadata = isW1
-  return (token.key_id, privateMetadata)
-```
 
 <h2 id=acknowledgments class=no-num>Acknowledgments</h2>
 

--- a/spec.bs
+++ b/spec.bs
@@ -56,12 +56,6 @@ urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch
         "publisher": "IETF",
         "title": "Oblivious Pseudorandom Functions (OPRFs) using Prime-Order Groups"
     },
-    "HTC": {
-        "authors": ["A. Faz-Hernandez", "S. Scott", "N. Sullivan", "R.S. Wahby", "C.A. Wood"],
-        "href": "https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-07",
-        "publisher": "IETF",
-        "title": "Hashing to Elliptic Curves"
-    },
     "ISSUER-PROTOCOL": {
         "authors": ["S. Valdez", "A. Bulut", "S. Schlesinger"],
         "href": "https://github.com/WICG/trust-token-api/blob/main/ISSUER_PROTOCOL.md",

--- a/spec.bs
+++ b/spec.bs
@@ -55,6 +55,12 @@ urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch
         "href": "https://www.ietf.org/archive/id/draft-irtf-cfrg-voprf-13.html",
         "publisher": "IETF",
         "title": "Oblivious Pseudorandom Functions (OPRFs) using Prime-Order Groups"
+    },
+    "HTC": {
+        "authors": ["A. Faz-Hernandez", "S. Scott", "N. Sullivan", "R.S. Wahby", "C.A. Wood"],
+        "href": "https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-07",
+        "publisher": "IETF",
+        "title": "Hashing to Elliptic Curves"
     }
 }
 </pre>
@@ -435,6 +441,207 @@ Sec-PST-Count: Issuing 3 tokens.
 ```
 </div>
 
+Following are the keys used for the PrivateStateTokenV3PMB protocol encoded in TLS presentation language, consisting of elliptic curve scalars and points based
+on the curve choice (P-384).
+
+```
+opaque ECPoint<1..2^16-1>; // X9.62 Uncompressed point.
+opaque Scalar<Ns>; // big-endian bytestring
+
+struct {
+  // Corresponding to the FALSE private metadata bit (x0, y0).
+  Scalar x0;
+  Scalar y0;
+  // Corresponding to the TRUE private metadata bit (x1, y1).
+  Scalar x1;
+  Scalar y1;
+  // Corresponding to the token validity (x˜, y˜).
+  Scalar xs;
+  Scalar ys;
+} TrustTokenSecretKey;
+
+struct {
+  ECPoint pub0; // Corresponding to the FALSE private metadata bit.
+  ECPoint pub1; // Corresponding to the TRUE private metadata bit.
+  ECPoint pubs; // Corresponding to the token validity check.
+} PrivateStateTokenPublicKey;
+```
+
+We use serialization schemes and hashes from draft 07 of the hash-to-curve specification, [[HTC]].
+
+`Ht(t)` is defined as P384_XMD:SHA-512_SSWU_RO_ with a big-endian bytestring input of `t` and a dst of "PMBTokens Experiment V2 HashT".
+
+`Hs(T, s)` is defined to be P384_XMD:SHA-512_SSWU_RO_ with a bytestring input of `T` with the following content and a dst of "PMBTokens Experiment V2 HashS".
+
+```
+struct {
+  ECPoint t;
+  opaque s[Nn];
+} T;
+```
+
+The [[HTC]] document does not define hash to scalars, so `Hc(x)` is defined to be the output of the hash_to_field function with the following parameters:
+
+* `DST` is "PMBTokens Experiment V2 HashC"
+* `F`, `p`, and `m` are defined according to the finite field `GF(r)`, where `r` is the order of P-384. Note this is a different modulus from `hash_to_field` as used in P384_XMD:SHA-512_SSWU_RO.
+* `L` is 72, derived based on P384_XMD:SHA-512_SSWU_RO_'s security parameter `k` (192), and `p` defined above.
+* `expand_message` uses the corresponding function from P384_XMD:SHA-512_SSWU_RO_.
+
+When used in the DLEQ proof, `Hc` takes the following input.
+
+```
+struct {
+  uint8 label[6] = "DLEQ2\0";
+  ECPoint X;
+  ECPoint T;
+  ECPoint S;
+  ECPoint W;
+  ECPoint K0;
+  ECPoint K1;
+} DLEQInput; // Used for DLEQ proof.
+```
+
+When used in the DLEQOR proof, `Hc` takes the following input.
+
+```
+struct {
+  uint8 label[8] = "DLEQOR2\0";
+  ECPoint X0;
+  ECPoint X1;
+  ECPoint T;
+  ECPoint S;
+  ECPoint W;
+  ECPoint K00;
+  ECPoint K01;
+  ECPoint K10;
+  ECPoint K11;
+} DLEQORInput; // Used for DLEQOR proof.
+```
+
+When used in the DLEQ batching step, `Hc` is called once for each `e_i` output, with the following input. The `index` field contains `i`.
+
+```
+struct {
+  uint8 label[11] = "DLEQ Batch\0";
+  ECPoint pubs;
+  ECPoint pub0;
+  ECPoint pub1;
+  ECPoint T'0;
+  ECPoint S'0;
+  ECPoint Wp0;
+  ECPoint Wsp0;
+  ...
+  ECPoint T'n;
+  ECPoint S'n;
+  ECPoint Wpn;
+  ECPoint Wspn;
+  uint16 index;
+} DLEQBatchInput; // Used for Batch proof.
+```
+
+The `Issue` function corresponds to the **AT.Sig** stage of the [[PMB]] protocol.
+
+Inputs:
+
+* count (the number of tokens being requested, from the IssueRequest)
+* nonces (the list of nonces to sign)
+* secretKey (the secret key that should be used to sign this request, determined by the public metadata)
+* publicKey (the public key corresponding to the secretKey)
+* keyID (the ID corresponding to this key)
+* privateMetadata (the boolean value corresponding to the private metadata value)
+* toIssue (the number of tokens to issue)
+
+Outputs:
+
+* issued (the number of tokens being issued)
+* keyID (the key used to sign these tokens)
+* signed (the list of signed nonces)
+* cs, us, vs, c0, u0, v0, c1, u1, v1 (the list of scalars corresponding to the zero-knowledge proof)
+
+```
+Issue:
+  issued = min(count, toIssue)
+  xb,yb = secretKey.x1, secretKey.y1
+  if privateMetadata == 0:
+    xb,yb = secretKey.x0, secretKey.y0
+  signed = []
+  T,S,W,Ws = [], [], [], []
+  for i in 0..issued:
+    T' = nonces[i]
+    s ←$ {0, 1}λ
+    S' = Hs(T', s)
+    Wp = xb*T' + yb*S'
+    Wsp = secretKey.xs*T' + secretKey.ys*S'
+    T,S,W,Ws += T', S', Wp, Wsp
+    signed += SignedNonce{s, Wp, Wsp}
+  proof = DLEQbatched.P((publicKey,T,S,W,Ws),(secretKey.xs, secretKey.ys, xb, yb))
+  return (issued, keyID, signed, proof)
+
+DLEQbatched.P((X,T,S,W,Ws),(xs, ys, xb, yb)):
+  e0,...,em = Hc(X,T,S,W,Ws)
+  Tt = Sum(ej*Tj) // over j from 0 to m
+  St = Sum(ej*Sj) // over j from 0 to m
+  Wt = Sum(ej*Wj) // over j from 0 to m
+  Wst = Sum(ej*Wsj) // over j from 0 to m
+  dleqProof = DLEQ2.P((X,T,S,Ws), (xs,ys)) // cs,us,vs
+  dleqorProof = DLEQOR2.P((X,T,S,W), (xb,yb)) // c0,c1,u0,u1,v0,v1
+  return dleqProof + dleqorProof
+```
+
+`DLEQOR2.P` is specified by replacing `n = 2` in the above and `DLEQ2.P`
+is specified by replacing `n = 1` in the below procedure.
+
+```
+DLEQOR.P((X, T, S, W), (xb, yb)):
+  k0, k1 sampled uniformly from Z^2_p
+  Kb = k0 * (G; T) + k1 * (H; S)
+  for i in [n], i != b:
+    ci, ui, vi sampled uniformly from Z_p
+    K = ui * (G; T) + vi * (H; S) - ci * (Xi; W)
+  c = Hc((X, T, S, W), K0, ..., Nn)
+  cb = c - Sum(ci) // over i in [n] not equal to b
+  ub = k0 + cb * xb
+  vb = k1 + cb * yb
+  return (c, u, v)
+```
+
+The issuance request contains an `IssueRequest` structure defined below.
+
+```
+struct {
+  uint16 count;
+  ECPoint nonces[count];
+} IssueRequest;
+```
+
+The issuance response contains an `IssueResponse` structure defined below.
+
+```
+struct {
+  opaque s<Nn>; // big-endian bytestring
+  ECPoint Wp;
+  ECPoint Wsp;
+} SignedNonce;
+
+struct {
+  Scalar cs;
+  Scalar us;
+  Scalar vs;
+  Scalar c0;
+  Scalar c1;
+  Scalar u0;
+  Scalar u1;
+  Scalar v0;
+  Scalar v1;
+} DLEQProof;
+
+struct {
+  uint16 issued;
+  uint32 key_id = keyID;
+  SignedNonce signed[issued];
+  opaque proof<1..2^16-1>; // Length-prefixed form of DLEQProof.
+} IssueResponse;
+```
 
 Browser Steps For Issue Response {#browser-issue-response}
 ----------------------------------------------------------
@@ -534,6 +741,62 @@ access/send the RR via Private State Token Fetch APIs. The RR is treated as an
 arbitrary blob of bytes from the issuer, that may have semantic meaning to
 downstream consumers.
 
+The `Redeem` function below corresponds to the **AT.VerValid** and **AT.ReadBit** stages of the [[PMB]] protocol.
+
+Inputs:
+
+*   token (The private state token to redeem)
+*   client\_data (the client data sent as part of the redemption request to include in the SRR)
+*   secretKey (the secret key that should be used to sign this request, determined by the public metadata)
+*   keys (dictionary from known key IDs to secret/public keys)
+
+Outputs:
+
+*   public_metadata (the ID of the keypair used to generate this token)
+*   private_metadata (the bit value of the private metadata, if aplicable)
+
+```
+Redeem:
+  secretKey, publicKey = keys[token.key_id]
+  T = Ht(token.nonce)
+  if token.Ws != secretKey.xs*T+secretKey.ys*token.S:
+    return 0 // Invalid validity verification.
+  W0 = secretKey.x0*T+secretKey.y0*token.S
+  W1 = secretKey.x1*T+secretKey.y1*token.S
+  // These equalities are timing-sensitive as they could be a timing side-channel.
+  isW0 = constantTimeEquality(tokenW, W0)
+  isW1 = constantTimeEquality(tokenW, W1)
+  if !(isW0 ^ isW1):
+    return 0 // Internal Error
+  privateMetadata = isW1
+  return (token.key_id, privateMetadata)
+```
+
+The Private State Token redemption request contains a `RedemptionRequest` structure as defined below.
+
+```
+struct {
+  uint32 key_id;
+  opaque nonce<nonce_size>;
+  ECPoint S;
+  ECPoint W;
+  ECPoint Ws;
+} Token;
+
+struct {
+  opaque token<1..2^16-1>; // Bytestring containing a serialized Token struct.
+  opaque client_data<1..2^16-1>;
+  uint64 redemption_time;
+} RedeemRequest;
+```
+
+The Private State Token redemption response contains a `RedemptionResponse` structure as defined below.
+
+```
+struct {
+  opaque rr<1..2^16-1>;
+} RedeemResponse;
+```
 
 Redemption Records {#redemption-records}
 ----------------------------------------

--- a/spec.bs
+++ b/spec.bs
@@ -896,7 +896,7 @@ struct {
 } PrivateStateTokenPublicKey;
 ```
 
-We use serialization schemes and hashes from draft 07 of the hash-to-curve specification, [[HTC]].
+We use serialization schemes and hashes from draft 07 of the hash-to-curve specification, [[!HTC]].
 
 `Ht(t)` is defined as P384_XMD:SHA-512_SSWU_RO_ with a big-endian bytestring input of `t` and a dst of "PMBTokens Experiment V2 HashT".
 
@@ -909,7 +909,7 @@ struct {
 } T;
 ```
 
-The [[HTC]] document does not define hash to scalars, so `Hc(x)` is defined to be the output of the hash_to_field function with the following parameters:
+The [[!HTC]] document does not define hash to scalars, so `Hc(x)` is defined to be the output of the hash_to_field function with the following parameters:
 
 * `DST` is "PMBTokens Experiment V2 HashC"
 * `F`, `p`, and `m` are defined according to the finite field `GF(r)`, where `r` is the order of P-384. Note this is a different modulus from `hash_to_field` as used in P384_XMD:SHA-512_SSWU_RO.
@@ -1105,7 +1105,7 @@ DLEQOR.P((X, T, S, W), (xb, yb)):
 Redemption
 ------------------------
 
-The `Redeem` function below corresponds to the **AT.VerValid** and **AT.ReadBit** stages of the [[PMB]] protocol.
+The `Redeem` function below corresponds to the **AT.VerValid** and **AT.ReadBit** stages of the [[!PMB]] protocol.
 
 Inputs:
 

--- a/spec.bs
+++ b/spec.bs
@@ -441,207 +441,7 @@ Sec-PST-Count: Issuing 3 tokens.
 ```
 </div>
 
-Following are the keys used for the PrivateStateTokenV3PMB protocol encoded in TLS presentation language, consisting of elliptic curve scalars and points based
-on the curve choice (P-384).
-
-```
-opaque ECPoint<1..2^16-1>; // X9.62 Uncompressed point.
-opaque Scalar<Ns>; // big-endian bytestring
-
-struct {
-  // Corresponding to the FALSE private metadata bit (x0, y0).
-  Scalar x0;
-  Scalar y0;
-  // Corresponding to the TRUE private metadata bit (x1, y1).
-  Scalar x1;
-  Scalar y1;
-  // Corresponding to the token validity (x˜, y˜).
-  Scalar xs;
-  Scalar ys;
-} TrustTokenSecretKey;
-
-struct {
-  ECPoint pub0; // Corresponding to the FALSE private metadata bit.
-  ECPoint pub1; // Corresponding to the TRUE private metadata bit.
-  ECPoint pubs; // Corresponding to the token validity check.
-} PrivateStateTokenPublicKey;
-```
-
-We use serialization schemes and hashes from draft 07 of the hash-to-curve specification, [[HTC]].
-
-`Ht(t)` is defined as P384_XMD:SHA-512_SSWU_RO_ with a big-endian bytestring input of `t` and a dst of "PMBTokens Experiment V2 HashT".
-
-`Hs(T, s)` is defined to be P384_XMD:SHA-512_SSWU_RO_ with a bytestring input of `T` with the following content and a dst of "PMBTokens Experiment V2 HashS".
-
-```
-struct {
-  ECPoint t;
-  opaque s[Nn];
-} T;
-```
-
-The [[HTC]] document does not define hash to scalars, so `Hc(x)` is defined to be the output of the hash_to_field function with the following parameters:
-
-* `DST` is "PMBTokens Experiment V2 HashC"
-* `F`, `p`, and `m` are defined according to the finite field `GF(r)`, where `r` is the order of P-384. Note this is a different modulus from `hash_to_field` as used in P384_XMD:SHA-512_SSWU_RO.
-* `L` is 72, derived based on P384_XMD:SHA-512_SSWU_RO_'s security parameter `k` (192), and `p` defined above.
-* `expand_message` uses the corresponding function from P384_XMD:SHA-512_SSWU_RO_.
-
-When used in the DLEQ proof, `Hc` takes the following input.
-
-```
-struct {
-  uint8 label[6] = "DLEQ2\0";
-  ECPoint X;
-  ECPoint T;
-  ECPoint S;
-  ECPoint W;
-  ECPoint K0;
-  ECPoint K1;
-} DLEQInput; // Used for DLEQ proof.
-```
-
-When used in the DLEQOR proof, `Hc` takes the following input.
-
-```
-struct {
-  uint8 label[8] = "DLEQOR2\0";
-  ECPoint X0;
-  ECPoint X1;
-  ECPoint T;
-  ECPoint S;
-  ECPoint W;
-  ECPoint K00;
-  ECPoint K01;
-  ECPoint K10;
-  ECPoint K11;
-} DLEQORInput; // Used for DLEQOR proof.
-```
-
-When used in the DLEQ batching step, `Hc` is called once for each `e_i` output, with the following input. The `index` field contains `i`.
-
-```
-struct {
-  uint8 label[11] = "DLEQ Batch\0";
-  ECPoint pubs;
-  ECPoint pub0;
-  ECPoint pub1;
-  ECPoint T'0;
-  ECPoint S'0;
-  ECPoint Wp0;
-  ECPoint Wsp0;
-  ...
-  ECPoint T'n;
-  ECPoint S'n;
-  ECPoint Wpn;
-  ECPoint Wspn;
-  uint16 index;
-} DLEQBatchInput; // Used for Batch proof.
-```
-
-The `Issue` function corresponds to the **AT.Sig** stage of the [[PMB]] protocol.
-
-Inputs:
-
-* count (the number of tokens being requested, from the IssueRequest)
-* nonces (the list of nonces to sign)
-* secretKey (the secret key that should be used to sign this request, determined by the public metadata)
-* publicKey (the public key corresponding to the secretKey)
-* keyID (the ID corresponding to this key)
-* privateMetadata (the boolean value corresponding to the private metadata value)
-* toIssue (the number of tokens to issue)
-
-Outputs:
-
-* issued (the number of tokens being issued)
-* keyID (the key used to sign these tokens)
-* signed (the list of signed nonces)
-* cs, us, vs, c0, u0, v0, c1, u1, v1 (the list of scalars corresponding to the zero-knowledge proof)
-
-```
-Issue:
-  issued = min(count, toIssue)
-  xb,yb = secretKey.x1, secretKey.y1
-  if privateMetadata == 0:
-    xb,yb = secretKey.x0, secretKey.y0
-  signed = []
-  T,S,W,Ws = [], [], [], []
-  for i in 0..issued:
-    T' = nonces[i]
-    s ←$ {0, 1}λ
-    S' = Hs(T', s)
-    Wp = xb*T' + yb*S'
-    Wsp = secretKey.xs*T' + secretKey.ys*S'
-    T,S,W,Ws += T', S', Wp, Wsp
-    signed += SignedNonce{s, Wp, Wsp}
-  proof = DLEQbatched.P((publicKey,T,S,W,Ws),(secretKey.xs, secretKey.ys, xb, yb))
-  return (issued, keyID, signed, proof)
-
-DLEQbatched.P((X,T,S,W,Ws),(xs, ys, xb, yb)):
-  e0,...,em = Hc(X,T,S,W,Ws)
-  Tt = Sum(ej*Tj) // over j from 0 to m
-  St = Sum(ej*Sj) // over j from 0 to m
-  Wt = Sum(ej*Wj) // over j from 0 to m
-  Wst = Sum(ej*Wsj) // over j from 0 to m
-  dleqProof = DLEQ2.P((X,T,S,Ws), (xs,ys)) // cs,us,vs
-  dleqorProof = DLEQOR2.P((X,T,S,W), (xb,yb)) // c0,c1,u0,u1,v0,v1
-  return dleqProof + dleqorProof
-```
-
-`DLEQOR2.P` is specified by replacing `n = 2` in the above and `DLEQ2.P`
-is specified by replacing `n = 1` in the below procedure.
-
-```
-DLEQOR.P((X, T, S, W), (xb, yb)):
-  k0, k1 sampled uniformly from Z^2_p
-  Kb = k0 * (G; T) + k1 * (H; S)
-  for i in [n], i != b:
-    ci, ui, vi sampled uniformly from Z_p
-    K = ui * (G; T) + vi * (H; S) - ci * (Xi; W)
-  c = Hc((X, T, S, W), K0, ..., Nn)
-  cb = c - Sum(ci) // over i in [n] not equal to b
-  ub = k0 + cb * xb
-  vb = k1 + cb * yb
-  return (c, u, v)
-```
-
-The issuance request contains an `IssueRequest` structure defined below.
-
-```
-struct {
-  uint16 count;
-  ECPoint nonces[count];
-} IssueRequest;
-```
-
-The issuance response contains an `IssueResponse` structure defined below.
-
-```
-struct {
-  opaque s<Nn>; // big-endian bytestring
-  ECPoint Wp;
-  ECPoint Wsp;
-} SignedNonce;
-
-struct {
-  Scalar cs;
-  Scalar us;
-  Scalar vs;
-  Scalar c0;
-  Scalar c1;
-  Scalar u0;
-  Scalar u1;
-  Scalar v0;
-  Scalar v1;
-} DLEQProof;
-
-struct {
-  uint16 issued;
-  uint32 key_id = keyID;
-  SignedNonce signed[issued];
-  opaque proof<1..2^16-1>; // Length-prefixed form of DLEQProof.
-} IssueResponse;
-```
+The details for servers implementing this protocol can be found in [[#crypto]].
 
 Browser Steps For Issue Response {#browser-issue-response}
 ----------------------------------------------------------
@@ -658,6 +458,8 @@ To process a response to an issue request, browser carries out the following ste
     b. Else, return an error.
 
 Issue: Define this in terms of fetch
+
+The details for servers implementing this protocol can be found in [[#crypto]].
 
 Redeeming Tokens {#redeeming-tokens}
 ====================================
@@ -740,63 +542,6 @@ redeemed token's issuance. The RR is HTTP-only and JavaScript is only able to
 access/send the RR via Private State Token Fetch APIs. The RR is treated as an
 arbitrary blob of bytes from the issuer, that may have semantic meaning to
 downstream consumers.
-
-The `Redeem` function below corresponds to the **AT.VerValid** and **AT.ReadBit** stages of the [[PMB]] protocol.
-
-Inputs:
-
-*   token (The private state token to redeem)
-*   client\_data (the client data sent as part of the redemption request to include in the SRR)
-*   secretKey (the secret key that should be used to sign this request, determined by the public metadata)
-*   keys (dictionary from known key IDs to secret/public keys)
-
-Outputs:
-
-*   public_metadata (the ID of the keypair used to generate this token)
-*   private_metadata (the bit value of the private metadata, if aplicable)
-
-```
-Redeem:
-  secretKey, publicKey = keys[token.key_id]
-  T = Ht(token.nonce)
-  if token.Ws != secretKey.xs*T+secretKey.ys*token.S:
-    return 0 // Invalid validity verification.
-  W0 = secretKey.x0*T+secretKey.y0*token.S
-  W1 = secretKey.x1*T+secretKey.y1*token.S
-  // These equalities are timing-sensitive as they could be a timing side-channel.
-  isW0 = constantTimeEquality(tokenW, W0)
-  isW1 = constantTimeEquality(tokenW, W1)
-  if !(isW0 ^ isW1):
-    return 0 // Internal Error
-  privateMetadata = isW1
-  return (token.key_id, privateMetadata)
-```
-
-The Private State Token redemption request contains a `RedemptionRequest` structure as defined below.
-
-```
-struct {
-  uint32 key_id;
-  opaque nonce<nonce_size>;
-  ECPoint S;
-  ECPoint W;
-  ECPoint Ws;
-} Token;
-
-struct {
-  opaque token<1..2^16-1>; // Bytestring containing a serialized Token struct.
-  opaque client_data<1..2^16-1>;
-  uint64 redemption_time;
-} RedeemRequest;
-```
-
-The Private State Token redemption response contains a `RedemptionResponse` structure as defined below.
-
-```
-struct {
-  opaque rr<1..2^16-1>;
-} RedeemResponse;
-```
 
 Redemption Records {#redemption-records}
 ----------------------------------------
@@ -1118,6 +863,278 @@ Status: standard
 Author/Change controller: IETF
 
 Specification document: this specification ([[#sec-private-state-token-version]])
+
+Cryptographic Protocol {#crypto}
+===================================
+
+Data Serialization
+------------------------
+
+Following are the keys used for the PrivateStateTokenV3PMB protocol encoded in TLS presentation language, consisting of elliptic curve scalars and points based
+on the curve choice (P-384).
+
+```
+opaque ECPoint<1..2^16-1>; // X9.62 Uncompressed point.
+opaque Scalar<Ns>; // big-endian bytestring
+
+struct {
+  // Corresponding to the FALSE private metadata bit (x0, y0).
+  Scalar x0;
+  Scalar y0;
+  // Corresponding to the TRUE private metadata bit (x1, y1).
+  Scalar x1;
+  Scalar y1;
+  // Corresponding to the token validity (x˜, y˜).
+  Scalar xs;
+  Scalar ys;
+} TrustTokenSecretKey;
+
+struct {
+  ECPoint pub0; // Corresponding to the FALSE private metadata bit.
+  ECPoint pub1; // Corresponding to the TRUE private metadata bit.
+  ECPoint pubs; // Corresponding to the token validity check.
+} PrivateStateTokenPublicKey;
+```
+
+We use serialization schemes and hashes from draft 07 of the hash-to-curve specification, [[HTC]].
+
+`Ht(t)` is defined as P384_XMD:SHA-512_SSWU_RO_ with a big-endian bytestring input of `t` and a dst of "PMBTokens Experiment V2 HashT".
+
+`Hs(T, s)` is defined to be P384_XMD:SHA-512_SSWU_RO_ with a bytestring input of `T` with the following content and a dst of "PMBTokens Experiment V2 HashS".
+
+```
+struct {
+  ECPoint t;
+  opaque s[Nn];
+} T;
+```
+
+The [[HTC]] document does not define hash to scalars, so `Hc(x)` is defined to be the output of the hash_to_field function with the following parameters:
+
+* `DST` is "PMBTokens Experiment V2 HashC"
+* `F`, `p`, and `m` are defined according to the finite field `GF(r)`, where `r` is the order of P-384. Note this is a different modulus from `hash_to_field` as used in P384_XMD:SHA-512_SSWU_RO.
+* `L` is 72, derived based on P384_XMD:SHA-512_SSWU_RO_'s security parameter `k` (192), and `p` defined above.
+* `expand_message` uses the corresponding function from P384_XMD:SHA-512_SSWU_RO_.
+
+When used in the DLEQ proof, `Hc` takes the following input.
+
+```
+struct {
+  uint8 label[6] = "DLEQ2\0";
+  ECPoint X;
+  ECPoint T;
+  ECPoint S;
+  ECPoint W;
+  ECPoint K0;
+  ECPoint K1;
+} DLEQInput; // Used for DLEQ proof.
+```
+
+When used in the DLEQOR proof, `Hc` takes the following input.
+
+```
+struct {
+  uint8 label[8] = "DLEQOR2\0";
+  ECPoint X0;
+  ECPoint X1;
+  ECPoint T;
+  ECPoint S;
+  ECPoint W;
+  ECPoint K00;
+  ECPoint K01;
+  ECPoint K10;
+  ECPoint K11;
+} DLEQORInput; // Used for DLEQOR proof.
+```
+
+When used in the DLEQ batching step, `Hc` is called once for each `e_i` output, with the following input. The `index` field contains `i`.
+
+```
+struct {
+  uint8 label[11] = "DLEQ Batch\0";
+  ECPoint pubs;
+  ECPoint pub0;
+  ECPoint pub1;
+  ECPoint T'0;
+  ECPoint S'0;
+  ECPoint Wp0;
+  ECPoint Wsp0;
+  ...
+  ECPoint T'n;
+  ECPoint S'n;
+  ECPoint Wpn;
+  ECPoint Wspn;
+  uint16 index;
+} DLEQBatchInput; // Used for Batch proof.
+```
+
+The issuance request contains an `IssueRequest` structure defined below.
+
+```
+struct {
+  uint16 count;
+  ECPoint nonces[count];
+} IssueRequest;
+```
+
+The issuance response contains an `IssueResponse` structure defined below.
+
+```
+struct {
+  opaque s<Nn>; // big-endian bytestring
+  ECPoint Wp;
+  ECPoint Wsp;
+} SignedNonce;
+
+struct {
+  Scalar cs;
+  Scalar us;
+  Scalar vs;
+  Scalar c0;
+  Scalar c1;
+  Scalar u0;
+  Scalar u1;
+  Scalar v0;
+  Scalar v1;
+} DLEQProof;
+
+struct {
+  uint16 issued;
+  uint32 key_id = keyID;
+  SignedNonce signed[issued];
+  opaque proof<1..2^16-1>; // Length-prefixed form of DLEQProof.
+} IssueResponse;
+```
+
+The redemption request contains a `RedemptionRequest` structure as defined below.
+
+```
+struct {
+  uint32 key_id;
+  opaque nonce<nonce_size>;
+  ECPoint S;
+  ECPoint W;
+  ECPoint Ws;
+} Token;
+
+struct {
+  opaque token<1..2^16-1>; // Bytestring containing a serialized Token struct.
+  opaque client_data<1..2^16-1>;
+  uint64 redemption_time;
+} RedeemRequest;
+```
+
+The Private State Token redemption response contains a `RedemptionResponse` structure as defined below.
+
+```
+struct {
+  opaque rr<1..2^16-1>;
+} RedeemResponse;
+```
+
+Issuance
+------------------------
+
+The `Issue` function corresponds to the **AT.Sig** stage of the [[!PMB]] protocol. We refer to
+what is called "blinding" in [[!PMB]] as "masking".
+
+Inputs:
+
+* count (the number of tokens being requested, from the IssueRequest)
+* nonces (the list of nonces to sign)
+* secretKey (the secret key that should be used to sign this request, determined by the public metadata)
+* publicKey (the public key corresponding to the secretKey)
+* keyID (the ID corresponding to this key)
+* privateMetadata (the boolean value corresponding to the private metadata value)
+* toIssue (the number of tokens to issue)
+
+Outputs:
+
+* issued (the number of tokens being issued)
+* keyID (the key used to sign these tokens)
+* signed (the list of signed nonces)
+* cs, us, vs, c0, u0, v0, c1, u1, v1 (the list of scalars corresponding to the zero-knowledge proof)
+
+```
+Issue:
+  issued = min(count, toIssue)
+  xb,yb = secretKey.x1, secretKey.y1
+  if privateMetadata == 0:
+    xb,yb = secretKey.x0, secretKey.y0
+  signed = []
+  T,S,W,Ws = [], [], [], []
+  for i in 0..issued:
+    T' = nonces[i]
+    s ←$ {0, 1}λ
+    S' = Hs(T', s)
+    Wp = xb*T' + yb*S'
+    Wsp = secretKey.xs*T' + secretKey.ys*S'
+    T,S,W,Ws += T', S', Wp, Wsp
+    signed += SignedNonce{s, Wp, Wsp}
+  proof = DLEQbatched.P((publicKey,T,S,W,Ws),(secretKey.xs, secretKey.ys, xb, yb))
+  return (issued, keyID, signed, proof)
+
+DLEQbatched.P((X,T,S,W,Ws),(xs, ys, xb, yb)):
+  e0,...,em = Hc(X,T,S,W,Ws)
+  Tt = Sum(ej*Tj) // over j from 0 to m
+  St = Sum(ej*Sj) // over j from 0 to m
+  Wt = Sum(ej*Wj) // over j from 0 to m
+  Wst = Sum(ej*Wsj) // over j from 0 to m
+  dleqProof = DLEQ2.P((X,T,S,Ws), (xs,ys)) // cs,us,vs
+  dleqorProof = DLEQOR2.P((X,T,S,W), (xb,yb)) // c0,c1,u0,u1,v0,v1
+  return dleqProof + dleqorProof
+```
+
+`DLEQOR2.P` is specified by replacing `n = 2` in the above and `DLEQ2.P`
+is specified by replacing `n = 1` in the below procedure.
+
+```
+DLEQOR.P((X, T, S, W), (xb, yb)):
+  k0, k1 sampled uniformly from Z^2_p
+  Kb = k0 * (G; T) + k1 * (H; S)
+  for i in [n], i != b:
+    ci, ui, vi sampled uniformly from Z_p
+    K = ui * (G; T) + vi * (H; S) - ci * (Xi; W)
+  c = Hc((X, T, S, W), K0, ..., Nn)
+  cb = c - Sum(ci) // over i in [n] not equal to b
+  ub = k0 + cb * xb
+  vb = k1 + cb * yb
+  return (c, u, v)
+```
+
+Redemption
+------------------------
+
+The `Redeem` function below corresponds to the **AT.VerValid** and **AT.ReadBit** stages of the [[PMB]] protocol.
+
+Inputs:
+
+*   token (The private state token to redeem)
+*   client\_data (the client data sent as part of the redemption request to include in the SRR)
+*   secretKey (the secret key that should be used to sign this request, determined by the public metadata)
+*   keys (dictionary from known key IDs to secret/public keys)
+
+Outputs:
+
+*   public_metadata (the ID of the keypair used to generate this token)
+*   private_metadata (the bit value of the private metadata, if aplicable)
+
+```
+Redeem:
+  secretKey, publicKey = keys[token.key_id]
+  T = Ht(token.nonce)
+  if token.Ws != secretKey.xs*T+secretKey.ys*token.S:
+    return 0 // Invalid validity verification.
+  W0 = secretKey.x0*T+secretKey.y0*token.S
+  W1 = secretKey.x1*T+secretKey.y1*token.S
+  // These equalities are timing-sensitive as they could be a timing side-channel.
+  isW0 = constantTimeEquality(tokenW, W0)
+  isW1 = constantTimeEquality(tokenW, W1)
+  if !(isW0 ^ isW1):
+    return 0 // Internal Error
+  privateMetadata = isW1
+  return (token.key_id, privateMetadata)
+```
 
 <h2 id=acknowledgments class=no-num>Acknowledgments</h2>
 


### PR DESCRIPTION
Mostly moved what was in ISSUER_PROTOCOL.md over to spec.bs, made some minor language changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/SamuelSchlesinger/trust-token-api/pull/158.html" title="Last updated on Feb 17, 2023, 3:16 PM UTC (8ad4d13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/158/9fb6604...SamuelSchlesinger:8ad4d13.html" title="Last updated on Feb 17, 2023, 3:16 PM UTC (8ad4d13)">Diff</a>