### PR TITLE
Fix some list numbering/formatting

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -450,9 +450,9 @@ To process a response to an issue request, browser carries out the following ste
        `Success` response bearing 0 tokens.
  1. Strip the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the
     cryptographic procedures to obtain a list of unmasked tokens.
-    a. If the cryptographic procedure succeeds, associate the tokens with the
+    1. If the cryptographic procedure succeeds, associate the tokens with the
           issuing key’s label and store the tokens.
-    b. Else, return an error.
+    1. Else, return an error.
 
 Issue: Define this in terms of fetch
 

--- a/spec.bs
+++ b/spec.bs
@@ -395,11 +395,10 @@ To <dfn>append private state token issue request headers</dfn> given a [=/reques
 
  1. Let |tokens| be the result of [=generate masked tokens|generating masked tokens=] with |numTokens|.
  1. Configure the HTTP request.
-               a. Set a load flag to bypass the HTTP cache.
-          b. Add <a http-header>Sec-Private-State-Token</a> request header containing a
-                      base64-encoded version of the bytestring of tokens
-                      generated in Step 11.
-               c. Add <a http-header>Sec-Private-State-Token-Version</a> request header that specifies
+     1. Set a load flag to bypass the HTTP cache.
+     1. Add <a http-header>Sec-Private-State-Token</a> request header containing a
+                      base64-encoded version of |tokens|.
+     1. Add <a http-header>Sec-Private-State-Token-Version</a> request header that specifies
                       the version of the cryptographic protocol used.
 
      Issue: This step should append structured headers using [=header list/set a structured field value=]
@@ -447,9 +446,9 @@ Browser Steps For Issue Response {#browser-issue-response}
 To process a response to an issue request, browser carries out the following steps.
 
  1. If the response has no <a http-header>Sec-Private-State-Token</a> header, return an error.
- 2. If the response has an empty <a http-header>Sec-Private-State-Token</a> header, return; this is a
+ 1. If the response has an empty <a http-header>Sec-Private-State-Token</a> header, return; this is a
        `Success` response bearing 0 tokens.
- 3. Strip the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the
+ 1. Strip the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the
     cryptographic procedures to obtain a list of unmasked tokens.
     a. If the cryptographic procedure succeeds, associate the tokens with the
           issuing key’s label and store the tokens.


### PR DESCRIPTION
This fixes some formatting, since Bikeshed/Markdown doesn't support lettered lists. It also fixes a numbering mismatch, since _I believe_ the bytestring being referred to is `tokens`, which was defined in step 12, not step 11.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cfredric/trust-token-api/pull/173.html" title="Last updated on Feb 17, 2023, 3:53 PM UTC (7b8c31c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/173/5f1bc15...cfredric:7b8c31c.html" title="Last updated on Feb 17, 2023, 3:53 PM UTC (7b8c31c)">Diff</a>