### PR TITLE
Specify error types when processing issue responses

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -455,7 +455,9 @@ To process a response to an issue request, browser carries out the following ste
  1. Let |p| be [=a new promise=].
  1. If the response has no <a http-header>Sec-Private-State-Token</a> header, [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
  1. If the response has an empty <a http-header>Sec-Private-State-Token</a> header, [=/resolve=] |p| with {{undefined}} and return |p|. (This is a `Success` response bearing 0 tokens.)
- 1. Strip the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the cryptographic procedures to obtain a list of unmasked tokens.
+ 1. Remove the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the cryptographic procedures to obtain a list of unmasked tokens.
+ 
+ Issue: Define "cryptographic procedures to obtain a list of unmasked tokens"
     1. If the cryptographic procedure succeeds, associate the tokens with the issuing key's label and store the tokens. [=/Resolve=] |p| with {{undefined}} and return |p|.
     1. Else, [=/reject=] |p| with a "{{DataError}}" {{DOMException}} and return |p|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -452,14 +452,12 @@ Browser Steps For Issue Response {#browser-issue-response}
 
 To process a response to an issue request, browser carries out the following steps.
 
- 1. If the response has no <a http-header>Sec-Private-State-Token</a> header, return an error.
- 1. If the response has an empty <a http-header>Sec-Private-State-Token</a> header, return; this is a
-       `Success` response bearing 0 tokens.
- 1. Strip the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the
-    cryptographic procedures to obtain a list of unmasked tokens.
-    1. If the cryptographic procedure succeeds, associate the tokens with the
-          issuing key’s label and store the tokens.
-    1. Else, return an error.
+ 1. Let |p| be [=a new promise=].
+ 1. If the response has no <a http-header>Sec-Private-State-Token</a> header, [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
+ 1. If the response has an empty <a http-header>Sec-Private-State-Token</a> header, [=/resolve=] |p| with {{undefined}} and return |p|. (This is a `Success` response bearing 0 tokens.)
+ 1. Strip the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the cryptographic procedures to obtain a list of unmasked tokens.
+    1. If the cryptographic procedure succeeds, associate the tokens with the issuing key's label and store the tokens. [=/Resolve=] |p| with {{undefined}} and return |p|.
+    1. Else, [=/reject=] |p| with a "{{DataError}}" {{DOMException}} and return |p|.
 
 Issue: Define this in terms of fetch
 


### PR DESCRIPTION
This fixes #170.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cfredric/trust-token-api/pull/179.html" title="Last updated on Feb 17, 2023, 4:42 PM UTC (6ee5f6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/179/0a21f5b...cfredric:6ee5f6e.html" title="Last updated on Feb 17, 2023, 4:42 PM UTC (6ee5f6e)">Diff</a>