### PR TITLE
Rewrite issue response handling via Fetch spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -462,7 +462,7 @@ The details for servers implementing this protocol can be found in [[!ISSUER-PRO
 Browser Steps For Issue Response {#browser-issue-response}
 ----------------------------------------------------------
 
-To <dfn>handle an issue request</dfn>, given [=request=] |request| and [=response=] |response|, run the following steps:
+To <dfn>handle an issue response</dfn>, given [=request=] |request| and [=response=] |response|, run the following steps:
 
 1. If |request|'s [=request/header list=] [=header list/contains|does not contain=] <a http-header>Sec-Private-State-Token</a>, return null.
 1. Let |header| be the result of [=header list/get|getting=] <a http-header>Sec-Private-State-Token</a> from |response|'s [=response/header list=].

--- a/spec.bs
+++ b/spec.bs
@@ -462,20 +462,29 @@ The details for servers implementing this protocol can be found in [[!ISSUER-PRO
 Browser Steps For Issue Response {#browser-issue-response}
 ----------------------------------------------------------
 
-To process a response to an issue request, browser carries out the following steps.
+To <dfn>handle an issue request</dfn>, given [=request=] |request| and [=response=] |response|, run the following steps:
 
- 1. Let |p| be [=a new promise=].
- 1. If the response has no <a http-header>Sec-Private-State-Token</a> header, [=/reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
- 1. If the response has an empty <a http-header>Sec-Private-State-Token</a> header, [=/resolve=] |p| with {{undefined}} and return |p|. (This is a `Success` response bearing 0 tokens.)
- 1. Remove the <a http-header>Sec-Private-State-Token</a> header from the response and carry out the cryptographic procedures to obtain a list of unmasked tokens.
- 
- Issue(190): Define "cryptographic procedures to obtain a list of unmasked tokens"
-    1. If the cryptographic procedure succeeds, associate the tokens with the issuing key's label and store the tokens. [=/Resolve=] |p| with {{undefined}} and return |p|.
-    1. Else, [=/reject=] |p| with a "{{DataError}}" {{DOMException}} and return |p|.
+1. If |request|'s [=request/header list=] [=header list/contains|does not contain=] <a http-header>Sec-Private-State-Token</a>, return null.
+1. Let |header| be the result of [=header list/get|getting=] <a http-header>Sec-Private-State-Token</a> from |response|'s [=response/header list=].
+1. If |header| is null, return a [=network error=].
+1. If |header| is empty, return null.
+1. [=header list/delete|Delete=] <a http-header>Sec-Private-State-Token</a> from |response|'s [=response/header list=].
+1. Let |unmasked tokens| be the result of carrying out the cryptographic procedures to obtain a list of unmasked tokens.
+1. If |unmasked tokens| is an error, return a [=network error=].
+1. Associate |unmasked tokens| with the issuing key's label and store the tokens.
+1. Return null.
 
-Issue: Define this in terms of fetch
+Issue(190): Define "cryptographic procedures to obtain a list of unmasked tokens"
 
 The details for servers implementing this protocol can be found in [[!ISSUER-PROTOCOL]].
+
+<h3 id="modification-to-http-fetch-steps-header">Modification to HTTP fetch steps</h3>
+The following steps will be added to the [=HTTP fetch=] steps, before checking the redirect status (i.e. "If |actualResponse|'s status is a redirect status, ..."):
+
+1. Let |issue response result| be the result of [=handle an issue response|handling an issue response=], given [=request=] |request| and [=response=] |actualResponse| as input.
+1. If |issue response result| is a [=network error=], return |issue response result|.
+
+<span class=XXX>TODO: make the modification directly to the fetch spec.</span>
 
 Redeeming Tokens {#redeeming-tokens}
 ====================================

--- a/spec.bs
+++ b/spec.bs
@@ -465,8 +465,8 @@ Browser Steps For Issue Response {#browser-issue-response}
 To <dfn>handle an issue response</dfn>, given [=request=] |request| and [=response=] |response|, run the following steps:
 
 1. If |request|'s [=request/header list=] [=header list/contains|does not contain=] <a http-header>Sec-Private-State-Token</a>, return null.
+1. If |response|'s [=response/header list=] [=header list/contains|does not contain=] <a http-header>Sec-Private-State-Token</a>, return a [=network error=].
 1. Let |header| be the result of [=header list/get|getting=] <a http-header>Sec-Private-State-Token</a> from |response|'s [=response/header list=].
-1. If |header| is null, return a [=network error=].
 1. If |header| is empty, return null.
 1. [=header list/delete|Delete=] <a http-header>Sec-Private-State-Token</a> from |response|'s [=response/header list=].
 1. Let |unmasked tokens| be the result of carrying out the cryptographic procedures to obtain a list of unmasked tokens.

--- a/spec.bs
+++ b/spec.bs
@@ -469,9 +469,9 @@ To <dfn>handle an issue response</dfn>, given [=request=] |request| and [=respon
 1. Let |header| be the result of [=header list/get|getting=] <a http-header>Sec-Private-State-Token</a> from |response|'s [=response/header list=].
 1. If |header| is empty, return null.
 1. [=header list/delete|Delete=] <a http-header>Sec-Private-State-Token</a> from |response|'s [=response/header list=].
-1. Let |unmasked tokens| be the result of carrying out the cryptographic procedures to obtain a list of unmasked tokens.
+1. Let |unmasked tokens| be the result of carrying out the cryptographic procedures to obtain a list of unmasked tokens given |header|.
 1. If |unmasked tokens| is an error, return a [=network error=].
-1. Associate |unmasked tokens| with the issuing key's label and store the tokens.
+1. Associate |unmasked tokens| with the issuing key's label and store |unmasked tokens|.
 1. Return null.
 
 Issue(190): Define "cryptographic procedures to obtain a list of unmasked tokens"

--- a/spec.bs
+++ b/spec.bs
@@ -479,7 +479,7 @@ Issue(190): Define "cryptographic procedures to obtain a list of unmasked tokens
 The details for servers implementing this protocol can be found in [[!ISSUER-PROTOCOL]].
 
 <h3 id="modification-to-http-fetch-steps-header">Modification to HTTP fetch steps</h3>
-The following steps will be added to the [=HTTP fetch=] steps, before checking the redirect status (i.e. "If |actualResponse|'s status is a redirect status, ..."):
+The following steps will be added to the [=HTTP fetch=] steps, before checking the redirect status (i.e. "7. If |actualResponse|'s status is a redirect status, ..."):
 
 1. Let |issue response result| be the result of [=handle an issue response|handling an issue response=], given [=request=] |request| and [=response=] |actualResponse| as input.
 1. If |issue response result| is a [=network error=], return |issue response result|.

--- a/spec.bs
+++ b/spec.bs
@@ -484,8 +484,6 @@ The following steps will be added to the [=HTTP fetch=] steps, before checking t
 1. Let |issue response result| be the result of [=handle an issue response|handling an issue response=], given [=request=] |request| and [=response=] |actualResponse| as input.
 1. If |issue response result| is a [=network error=], return |issue response result|.
 
-<span class=XXX>TODO: make the modification directly to the fetch spec.</span>
-
 Redeeming Tokens {#redeeming-tokens}
 ====================================
 


### PR DESCRIPTION
This rewrites the `Browser Steps for Issue Response` section in terms of modifications to the Fetch spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cfredric/trust-token-api/pull/186.html" title="Last updated on Feb 17, 2023, 9:34 PM UTC (cf44af6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/186/00b8efd...cfredric:cf44af6.html" title="Last updated on Feb 17, 2023, 9:34 PM UTC (cf44af6)">Diff</a>