### PR TITLE
Add version field in PrivateStateToken  dictionary

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -403,8 +403,9 @@ An issue request is created and fetched as demonstrated in the following snippet
 ```javascript
 let issueRequest = new Request("https://example.issuer:1234/issuer_path?public=0&private=0", {
   privateStateToken: {
-    type: "token-request",
+    type: "private-state-token",
     version: 1,
+    operation: "token-request",
     issuer: "https://example.issuer"
   }
 });
@@ -415,6 +416,12 @@ fetch(issueRequest);
 To <dfn>append private state token issue request headers</dfn> given a [=/request=] |request|, run the following steps:
 
  1. If |request|'s [=request/client=] is not a [=secure context=], return.
+ 1. If |type| is not specified, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |type| is not `"private-state-token"`, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |version| is not specified, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |version| is not `1`, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |operation| is not specified, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |operation| is not one of {{OperationType}}, throw a "{{TypeError}}" {{DOMException}}.
  1. Let |issuer| be |request|'s [=request/URL=]'s [=url/origin=].
  1. Let |topLevel| be |request|'s [=request/client=]'s [=environment/top-level origin=].
  1. If associating |issuer| with |topLevel| [=determine whether associating an issuer would exceed the top-level limit|would exceed the top level’s number-of-issuers limit=], return.
@@ -519,8 +526,9 @@ snippet. The default value for refreshPolicy is `'none'`.
 ```javascript
 let redemptionRequest = new Request('https://example.issuer:1234/redemption_path', {
   privateStateToken: {
-    type: 'token-redemption',
+    type: 'private-state-token',
     version: 1,
+    operation: 'token-redemption',
     issuer: 'https://example.issuer',
     refreshPolicy: {'none', 'refresh'}
   }
@@ -530,11 +538,17 @@ let redemptionRequest = new Request('https://example.issuer:1234/redemption_path
 
 To <dfn>set redemption headers</dfn> with [=/request=] |request| and a [=Redemption Record=] |record|:
  1. Let |redemption-result| be the redemption procedure result.
- 1. Let |version| be the version of the cryptographic protocol used.
+ 1. Let |cryptoVersion| be the version of the cryptographic protocol used.
  1. Let |token-lifetime| be the expiration time of the [=redemption record=] in seconds.
+ 1. If |type| is not specified, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |type| is not `"private-state-token"`, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |version| is not specified, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |version| is not `1`, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |operation| is not specified, throw a "{{TypeError}}" {{DOMException}}.
+ 1. If |operation| is not one of {{OperationType}}, throw a "{{TypeError}}" {{DOMException}}.
  1. [=header list/Set a structured field value=] given (<a http-header>`Sec-Private-State-Token`</a>, |redemption-result|)
                 in |request|'s header list.
- 1. [=header list/Set a structured field value=] given (<a http-header>`Sec-Private-State-Token-Version`</a>, |version|)
+ 1. [=header list/Set a structured field value=] given (<a http-header>`Sec-Private-State-Token-Version`</a>, |cryptoVersion|)
                 in |request|'s header list.
  1. Optionally, [=header list/set a structured field value=] given (<a http-header>`Sec-Private-State-Token-Lifetime`</a>, |token-lifetime|)
                 in |request|'s header list.

--- a/spec.bs
+++ b/spec.bs
@@ -416,12 +416,6 @@ fetch(issueRequest);
 To <dfn>append private state token issue request headers</dfn> given a [=/request=] |request|, run the following steps:
 
  1. If |request|'s [=request/client=] is not a [=secure context=], return.
- 1. If |type| is not specified, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |type| is not `"private-state-token"`, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |version| is not specified, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |version| is not `1`, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |operation| is not specified, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |operation| is not one of {{OperationType}}, throw a "{{TypeError}}" {{DOMException}}.
  1. Let |issuer| be |request|'s [=request/URL=]'s [=url/origin=].
  1. Let |topLevel| be |request|'s [=request/client=]'s [=environment/top-level origin=].
  1. If associating |issuer| with |topLevel| [=determine whether associating an issuer would exceed the top-level limit|would exceed the top level’s number-of-issuers limit=], return.
@@ -540,12 +534,6 @@ To <dfn>set redemption headers</dfn> with [=/request=] |request| and a [=Redempt
  1. Let |redemption-result| be the redemption procedure result.
  1. Let |cryptoVersion| be the version of the cryptographic protocol used.
  1. Let |token-lifetime| be the expiration time of the [=redemption record=] in seconds.
- 1. If |type| is not specified, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |type| is not `"private-state-token"`, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |version| is not specified, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |version| is not `1`, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |operation| is not specified, throw a "{{TypeError}}" {{DOMException}}.
- 1. If |operation| is not one of {{OperationType}}, throw a "{{TypeError}}" {{DOMException}}.
  1. [=header list/Set a structured field value=] given (<a http-header>`Sec-Private-State-Token`</a>, |redemption-result|)
                 in |request|'s header list.
  1. [=header list/Set a structured field value=] given (<a http-header>`Sec-Private-State-Token-Version`</a>, |cryptoVersion|)

--- a/spec.bs
+++ b/spec.bs
@@ -624,7 +624,6 @@ When invoked on {{Document}} |doc| with {{USVString}} |issuer| and {{USVString}}
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |type| is not `"private-state-token"`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
-1. If |version| is not `1`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |issuer|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |origin| be |parsedURL|'s [=/origin=].

--- a/spec.bs
+++ b/spec.bs
@@ -337,6 +337,13 @@ type that the specification supports at this time.
 enum TokenType { "private-state-token" };
 </pre>
 
+The {{TokenVersion}} is currently set to `1`, as this is the only `"private-state-token"`
+version that the specification supports at this time.
+
+<pre class=idl>
+enum TokenVersion { 1 };
+</pre>
+
 The {{OperationType}} refers to which operation the user agent is attempting to complete.
 
 <pre class=idl>
@@ -347,6 +354,8 @@ The {{PrivateStateToken}} contains the information required to make a fetch requ
 
 <pre class=idl>
 dictionary PrivateStateToken {
+  required TokenType type;
+  required TokenVersion version;
   required OperationType operation;
   RefreshPolicy refreshPolicy = "none";
   sequence&lt;USVString> issuers;
@@ -396,6 +405,7 @@ An issue request is created and fetched as demonstrated in the following snippet
 let issueRequest = new Request("https://example.issuer:1234/issuer_path?public=0&private=0", {
   privateStateToken: {
     type: "token-request",
+    version: 1,
     issuer: "https://example.issuer"
   }
 });
@@ -511,6 +521,7 @@ snippet. The default value for refreshPolicy is `'none'`.
 let redemptionRequest = new Request('https://example.issuer:1234/redemption_path', {
   privateStateToken: {
     type: 'token-redemption',
+    version: 1,
     issuer: 'https://example.issuer',
     refreshPolicy: {'none', 'refresh'}
   }
@@ -613,6 +624,7 @@ When invoked on {{Document}} |doc| with {{USVString}} |issuer| and {{USVString}}
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |type| is not `"private-state-token"`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
+1. If |version| is not `1`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |issuer|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |origin| be |parsedURL|'s [=/origin=].

--- a/spec.bs
+++ b/spec.bs
@@ -340,7 +340,7 @@ The {{TokenVersion}} is currently set to `1`, as this is the only `"private-stat
 version that the specification supports at this time.
 
 <pre class=idl>
-enum TokenVersion { 1 };
+enum TokenVersion { "1" };
 </pre>
 
 The {{OperationType}} refers to which operation the user agent is attempting to complete.


### PR DESCRIPTION
Add version field in PrivateStateToken  dictionary. Fixes #136.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aykutbulut/trust-token-api/pull/209.html" title="Last updated on Mar 9, 2023, 4:33 AM UTC (ba74165)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/209/4359cfb...aykutbulut:ba74165.html" title="Last updated on Mar 9, 2023, 4:33 AM UTC (ba74165)">Diff</a>