### PR TITLE
Rename PrivateStateToken dictionary to PrivateToken

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -350,10 +350,10 @@ The {{OperationType}} refers to which operation the user agent is attempting to 
 enum OperationType { "token-request", "send-redemption-record", "token-redemption" };
 </pre>
 
-The {{PrivateStateToken}} contains the information required to make a fetch request.
+The {{PrivateToken}} contains the information required to make a fetch request.
 
 <pre class=idl>
-dictionary PrivateStateToken {
+dictionary PrivateToken {
   required TokenType type;
   required TokenVersion version;
   required OperationType operation;
@@ -368,7 +368,7 @@ This specification adds a new property to the {{RequestInit}} dictionary:
 
 <pre class=idl>
 partial dictionary RequestInit {
-  PrivateStateToken privateStateToken;
+  PrivateToken privateToken;
 };
 </pre>
 
@@ -379,7 +379,7 @@ A [=/request=] has an associated <dfn for=request>token refresh policy</dfn>, wh
 
 Add the following steps to the <code><a constructor lt="Request()">new Request (<var ignore>input</var>, |init|])</a></code> constructor, before step 28 ("<code>Set [=this=]'s [=Request/request=] to |request|</code>"):
 
- 1. If |init|["{{RequestInit/privateStateToken}}"] [=map/exists=], then set <var ignore>request</var>'s [=request/token refresh policy=]</a> to |init|["{{RequestInit/privateStateToken}}"]["{{PrivateStateToken/refreshPolicy}}"].
+ 1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=], then set <var ignore>request</var>'s [=request/token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
 
 Modifications to http-network-or-cache fetch {#http-network-or-cache-fetch}
 ---------------------------------------------------------------
@@ -403,7 +403,7 @@ An issue request is created and fetched as demonstrated in the following snippet
 
 ```javascript
 let issueRequest = new Request("https://example.issuer:1234/issuer_path?public=0&private=0", {
-  privateStateToken: {
+  privateToken: {
     type: "token-request",
     version: 1,
     issuer: "https://example.issuer"
@@ -519,7 +519,7 @@ snippet. The default value for refreshPolicy is `'none'`.
 
 ```javascript
 let redemptionRequest = new Request('https://example.issuer:1234/redemption_path', {
-  privateStateToken: {
+  privateToken: {
     type: 'token-redemption',
     version: 1,
     issuer: 'https://example.issuer',

--- a/spec.bs
+++ b/spec.bs
@@ -624,7 +624,6 @@ When invoked on {{Document}} |doc| with {{USVString}} |issuer| and {{USVString}}
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |type| is not `"private-state-token"`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
-1. If |version| is not `1`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |issuer|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |origin| be |parsedURL|'s [=/origin=].

--- a/spec.bs
+++ b/spec.bs
@@ -337,6 +337,13 @@ type that the specification supports at this time.
 enum TokenType { "private-state-token" };
 </pre>
 
+The {{TokenVersion}} is currently set to `1`, as this is the only `"private-state-token"`
+version that the specification supports at this time.
+
+<pre class=idl>
+enum TokenVersion { 1 };
+</pre>
+
 The {{OperationType}} refers to which operation the user agent is attempting to complete.
 
 <pre class=idl>
@@ -347,6 +354,8 @@ The {{PrivateStateToken}} contains the information required to make a fetch requ
 
 <pre class=idl>
 dictionary PrivateStateToken {
+  required TokenType type;
+  required TokenVersion version;
   required OperationType operation;
   RefreshPolicy refreshPolicy = "none";
   sequence&lt;USVString> issuers;
@@ -396,6 +405,7 @@ An issue request is created and fetched as demonstrated in the following snippet
 let issueRequest = new Request("https://example.issuer:1234/issuer_path?public=0&private=0", {
   privateStateToken: {
     type: "token-request",
+    version: 1,
     issuer: "https://example.issuer"
   }
 });
@@ -511,6 +521,7 @@ snippet. The default value for refreshPolicy is `'none'`.
 let redemptionRequest = new Request('https://example.issuer:1234/redemption_path', {
   privateStateToken: {
     type: 'token-redemption',
+    version: 1,
     issuer: 'https://example.issuer',
     refreshPolicy: {'none', 'refresh'}
   }
@@ -613,6 +624,7 @@ When invoked on {{Document}} |doc| with {{USVString}} |issuer| and {{USVString}}
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
 1. If |type| is not `"private-state-token"`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
+1. If |version| is not `1`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |issuer|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |origin| be |parsedURL|'s [=/origin=].


### PR DESCRIPTION
Rename PrivateStateToken dictionary to PrivateToken. Token type is specified in the type field.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aykutbulut/trust-token-api/pull/211.html" title="Last updated on Feb 27, 2023, 8:27 PM UTC (fefdcf8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/211/ba6b858...aykutbulut:fefdcf8.html" title="Last updated on Feb 27, 2023, 8:27 PM UTC (fefdcf8)">Diff</a>