### PR TITLE
Fix bikeshed linking for resolve

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -20,6 +20,7 @@ Complain About: missing-example-ids yes
 spec:fetch; type:dfn; for:/; text:response
 spec:fetch; type:dfn; for:/; text:request
 spec:infra; type:dfn; text:list
+spec:webidl; type:dfn; text:resolve
 </pre>
 
 <pre class="anchors">


### PR DESCRIPTION
I get following warnings when I run bikeshed locally. I assumed the resolve we would like to refer is webidl not fileapi.

```
LINE ~636: Multiple possible 'resolve' dfn refs.
Arbitrarily chose https://w3c.github.io/FileAPI/#blob-url-resolve To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block: 
spec:fileapi; type:dfn; text:resolve
spec:webidl; type:dfn; text:resolve
[=resolve=]
LINE ~659: Multiple possible 'resolve' dfn refs.
Arbitrarily chose https://w3c.github.io/FileAPI/#blob-url-resolve To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block: 
spec:fileapi; type:dfn; text:resolve
spec:webidl; type:dfn; text:resolve
[=resolve=]
LINE ~663: Multiple possible 'resolve' dfn refs.
Arbitrarily chose https://w3c.github.io/FileAPI/#blob-url-resolve To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block: 
spec:fileapi; type:dfn; text:resolve
spec:webidl; type:dfn; text:resolve
[=resolve=]
 ✔  Successfully generated, with 3 linking errors
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/pull/212.html" title="Last updated on Feb 27, 2023, 8:55 PM UTC (ae10b48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/212/ba6b858...ae10b48.html" title="Last updated on Feb 27, 2023, 8:55 PM UTC (ae10b48)">Diff</a>