### PR TITLE
Rename PrivateStateToken dictionary

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -83,11 +83,15 @@ urlPrefix: https://tools.ietf.org/html/rfc8941; spec: rfc8941
 Goals {#goals}
 ==============
 
-The goal of the Private State Token API is to transfer a limited amount of signals across
+The goal of the Private State Tokens is to transfer a limited amount of signals across
 sites through time in a privacy preserving manner. It achieves this using
 privacy pass protocol [[!PRIVACY-PASS-ISSUANCE-PROTOCOL]] specified in the working
 documents of the IETF Privacy Pass Working Group [[PRIVACY-PASS-WG]]. Private
 State Tokens can be considered to be a web platform implementation of Privacy Pass.
+
+The spec introduces a new field in request dictionary to support token
+operations. It describes how Private State Tokens are utilized through this new
+dictionary.
 
 <!--
 
@@ -508,7 +512,7 @@ snippet. The default value for refreshPolicy is `'none'`.
 
 ```javascript
 let redemptionRequest = new Request('https://example.issuer:1234/redemption_path', {
-  privateStateToken: {
+  privateToken: {
     type: 'token-redemption',
     issuer: 'https://example.issuer',
     refreshPolicy: {'none', 'refresh'}


### PR DESCRIPTION
Rename PrivateStateToken dictionary to PrivateToken. Token type is specified in the type field. Fixes #210.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/pull/213.html" title="Last updated on Mar 8, 2023, 3:47 PM UTC (62d0a18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/213/ba6b858...62d0a18.html" title="Last updated on Mar 8, 2023, 3:47 PM UTC (62d0a18)">Diff</a>