### PR TITLE
Changed expirion to expiration

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -165,9 +165,9 @@ Requests to key commitment endpoints should result in a JSON response
     "batchsize": <batch size>,
     "keys": {
       <keyID>: { "Y": <base64-encoded public key>,
-                 "expiry": <key expirion data>},
+                 "expiry": <key expiration data>},
       <keyID>: { "Y": <base64-encoded public key>,
-                 "expiry": <key expirion data}, ...
+                 "expiry": <key expiration data}, ...
     }
   },
   ...

--- a/spec.bs
+++ b/spec.bs
@@ -165,9 +165,9 @@ Requests to key commitment endpoints should result in a JSON response
     "batchsize": <batch size>,
     "keys": {
       <keyID>: { "Y": <base64-encoded public key>,
-                 "expiry": <key expiration data>},
+                 "expiry": <key expiration date>},
       <keyID>: { "Y": <base64-encoded public key>,
-                 "expiry": <key expiration data}, ...
+                 "expiry": <key expiration date}, ...
     }
   },
   ...


### PR DESCRIPTION
Changed expirion to expiration, seems like it was a typo. Is data meant to be date as well?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/SamuelSchlesinger/trust-token-api/pull/234.html" title="Last updated on Apr 16, 2023, 11:58 AM UTC (108e278)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/234/f9a0507...SamuelSchlesinger:108e278.html" title="Last updated on Apr 16, 2023, 11:58 AM UTC (108e278)">Diff</a>