### PR TITLE
Add permission policy checks

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -375,28 +375,27 @@ To <dfn>unmask tokens</dfn> given [=key commitments=] |issuerKeys|, byte string 
 1. Return |result|.
 
 To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |input|, a {{RequestInit}} |init| and a {{Request}} |request| run the following steps:
-1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
-    1. Set |window| to |request|’s [=request/window=].
-    1. Set |document| to |window|’s [=associated Document=].
-    1. Let |origin| be |request|’s origin.
-    1. Set |request|'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
-    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
-        1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
-        1. Abort the remaining steps.
-    1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
-    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
-        1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
-        1. Abort the remaining steps.
-    1. [=Assert=]: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"send-redemption-record"</code>.
-    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] does not [=map/exists|exist=], then throw {{TypeError}}.
-    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] is [=list/empty=], then throw {{TypeError}}.
-    1. [=list/For each=] |issuer| of |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"]:
-        1. Let |issuerURL| be the the result of running the [=URL parser=] on |issuer|.
-        1. If |issuerURL| is failure, then throw {{TypeError}}.
-        1. If |issuerURL|'s [=url/scheme=] is not an [=HTTP(S) scheme=], then throw {{TypeError}}.
-        1. Let |issuerOrigin| be |issuerURL|'s [=/origin=].
-        1. If |issuerOrigin| is not a [=potentially trustworthy origin=], then throw {{TypeError}}.
-        1. [=list/Append=] |issuerURL| to <var ignore>request</var>'s [=request/private token issuers=].
+1. Set |window| to |request|’s [=request/window=].
+1. Set |document| to |window|’s [=associated Document=].
+1. Let |origin| be |request|’s origin.
+1. Set |request|'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
+1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
+    1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
+    1. Abort the remaining steps.
+1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
+1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
+    1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
+    1. Abort the remaining steps.
+1. [=Assert=]: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"send-redemption-record"</code>.
+1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] does not [=map/exists|exist=], then throw {{TypeError}}.
+1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] is [=list/empty=], then throw {{TypeError}}.
+1. [=list/For each=] |issuer| of |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"]:
+    1. Let |issuerURL| be the the result of running the [=URL parser=] on |issuer|.
+    1. If |issuerURL| is failure, then throw {{TypeError}}.
+    1. If |issuerURL|'s [=url/scheme=] is not an [=HTTP(S) scheme=], then throw {{TypeError}}.
+    1. Let |issuerOrigin| be |issuerURL|'s [=/origin=].
+    1. If |issuerOrigin| is not a [=potentially trustworthy origin=], then throw {{TypeError}}.
+    1. [=list/Append=] |issuerURL| to <var ignore>request</var>'s [=request/private token issuers=].
 
 
 Integration with Fetch {#fetch-integration}
@@ -474,7 +473,8 @@ A [=request=] has an associated <dfn for="request">pstPretokens</dfn>, which is 
 
 Add the following steps to the <code><a constructor lt="Request()">new Request (<var ignore>input</var>, |init|)</a></code> constructor, before step 28 ("<code>Set [=this=]'s [=Request/request=] to |request|</code>"):
 
-1. Run [=set private token property for request=] on |input|, |init| and |request|.
+1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
+    1. Run [=set private token property for request=] on |input|, |init| and |request|.
 
 
 Modifications to http-network-or-cache fetch {#http-network-or-cache-fetch}

--- a/spec.bs
+++ b/spec.bs
@@ -384,7 +384,7 @@ To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |in
     1. Abort the remaining steps.
 1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
-    1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
+    1. Set |request|'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
     1. Abort the remaining steps.
 1. [=Assert=]: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"send-redemption-record"</code>.
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] does not [=map/exists|exist=], then throw {{TypeError}}.

--- a/spec.bs
+++ b/spec.bs
@@ -452,8 +452,11 @@ Add the following steps to the <code><a constructor lt="Request()">new Request (
  1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
      1. Set <var ignore>request</var>'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
-         1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
-     1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
+         1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" returns false, then throw a "{{NotAllowedError}}" {{DOMException}}.
+         1. Abort the remaining steps.
+     1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false:
+         1. Throw a "{{NotAllowedError}}" {{DOMException}}.
+         1. Abort the remaining steps.
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
          1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
          1. Abort the remaining steps.

--- a/spec.bs
+++ b/spec.bs
@@ -441,7 +441,7 @@ Note: [=request/Private token refresh policy=] is ignored unless [=request/priva
 
 This specification defines two new [=policy-controlled features=]. Exactly one of these policy features applies for a given Private State Token operation.
 
-Policy identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-issuance</code></dfn>" applies for the <code>"token-request"</code> operation. The [=default allowlist=] for this feature is <code>["self"]</code>.
+The [=policy-controlled feature=] identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-issuance</code></dfn>" applies for the <code>"token-request"</code> operation. The [=default allowlist=] for this feature is <code>["self"]</code>.
 
 Policy identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-redemption</code></dfn>" applies for the <code>"send-redemption-record"</code> and <code>"token-redemption"</code> operations. The [=default allowlist=] for this feature is <code>["self"]</code>.
 

--- a/spec.bs
+++ b/spec.bs
@@ -375,19 +375,18 @@ To <dfn>unmask tokens</dfn> given [=key commitments=] |issuerKeys|, byte string 
 1. Return |result|.
 
 To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |input|, a {{RequestInit}} |init| and a {{Request}} |request| run the following steps:
-1. Set |window| to |request|’s [=request/window=].
-1. Set |document| to |window|’s [=associated Document=].
+1. Let |window| be |request|’s [=request/window=].
+1. Let |document| be |window|’s [=associated Document=].
 1. Let |origin| be |request|’s origin.
 1. Set |request|'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is {{OperationType/"token-request"}}:
     1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
     1. Abort the remaining steps.
-1. Assert: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is {{OperationType/"token-redemption"}} or {{OperationType/"send-redemption-record"}}
+1. Assert: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is {{OperationType/"token-redemption"}} or {{OperationType/"send-redemption-record"}}.
 1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
     1. Set |request|'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
     1. Abort the remaining steps.
-1. [=Assert=]: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"send-redemption-record"</code>.
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] does not [=map/exists|exist=], then throw {{TypeError}}.
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] is [=list/empty=], then throw {{TypeError}}.
 1. [=list/For each=] |issuer| of |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"]:

--- a/spec.bs
+++ b/spec.bs
@@ -374,6 +374,31 @@ To <dfn>unmask tokens</dfn> given [=key commitments=] |issuerKeys|, byte string 
 1. Let |result| ([=list=] of byte strings) be the result of running |unmaskOperation| on |pretokens| and |response|.
 1. Return |result|.
 
+To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |input|, a {{RequestInit}} |init| and a {{Request}} |request| run the following steps:
+1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
+    1. Set |window| to |request|’s [=request/window=].
+    1. Set |document| to |window|’s [=associated Document=].
+    1. Let |origin| be |request|’s origin.
+    1. Set |request|'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
+    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
+        1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
+        1. Abort the remaining steps.
+    1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
+    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
+        1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
+        1. Abort the remaining steps.
+    1. [=Assert=]: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"send-redemption-record"</code>.
+    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] does not [=map/exists|exist=], then throw {{TypeError}}.
+    1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] is [=list/empty=], then throw {{TypeError}}.
+    1. [=list/For each=] |issuer| of |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"]:
+        1. Let |issuerURL| be the the result of running the [=URL parser=] on |issuer|.
+        1. If |issuerURL| is failure, then throw {{TypeError}}.
+        1. If |issuerURL|'s [=url/scheme=] is not an [=HTTP(S) scheme=], then throw {{TypeError}}.
+        1. Let |issuerOrigin| be |issuerURL|'s [=/origin=].
+        1. If |issuerOrigin| is not a [=potentially trustworthy origin=], then throw {{TypeError}}.
+        1. [=list/Append=] |issuerURL| to <var ignore>request</var>'s [=request/private token issuers=].
+
+
 Integration with Fetch {#fetch-integration}
 ====================================
 
@@ -449,25 +474,7 @@ A [=request=] has an associated <dfn for="request">pstPretokens</dfn>, which is 
 
 Add the following steps to the <code><a constructor lt="Request()">new Request (<var ignore>input</var>, |init|)</a></code> constructor, before step 28 ("<code>Set [=this=]'s [=Request/request=] to |request|</code>"):
 
- 1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
-     1. Set <var ignore>request</var>'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
-     1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
-         1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" returns false, then throw a "{{NotAllowedError}}" {{DOMException}}.
-         1. Abort the remaining steps.
-     1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false, then throw a "{{NotAllowedError}}" {{DOMException}}.
-     1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
-         1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
-         1. Abort the remaining steps.
-     1. [=Assert=]: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"send-redemption-record"</code>.
-     1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] does not [=map/exists|exist=], then throw {{TypeError}}.
-     1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"] is [=list/empty=], then throw {{TypeError}}.
-     1. [=list/For each=] |issuer| of |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/issuers}}"]:
-         1. Let |issuerURL| be the the result of running the [=URL parser=] on |issuer|.
-         1. If |issuerURL| is failure, then throw {{TypeError}}.
-         1. If |issuerURL|'s [=url/scheme=] is not an [=HTTP(S) scheme=], then throw {{TypeError}}.
-         1. Let |issuerOrigin| be |issuerURL|'s [=/origin=].
-         1. If |issuerOrigin| is not a [=potentially trustworthy origin=], then throw {{TypeError}}.
-         1. [=list/Append=] |issuerURL| to <var ignore>request</var>'s [=request/private token issuers=].
+1. Run [=set private token property for request=] on |input|, |init| and |request|.
 
 
 Modifications to http-network-or-cache fetch {#http-network-or-cache-fetch}

--- a/spec.bs
+++ b/spec.bs
@@ -454,9 +454,7 @@ Add the following steps to the <code><a constructor lt="Request()">new Request (
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
          1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" returns false, then throw a "{{NotAllowedError}}" {{DOMException}}.
          1. Abort the remaining steps.
-     1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false:
-         1. Throw a "{{NotAllowedError}}" {{DOMException}}.
-         1. Abort the remaining steps.
+     1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false, then throw a "{{NotAllowedError}}" {{DOMException}}.
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
          1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
          1. Abort the remaining steps.

--- a/spec.bs
+++ b/spec.bs
@@ -382,6 +382,7 @@ To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |in
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is {{OperationType/"token-request"}}:
     1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
     1. Abort the remaining steps.
+1. Assert: |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is {{OperationType/"token-redemption"}} or {{OperationType/"send-redemption-record"}}
 1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
 1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
     1. Set |request|'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].

--- a/spec.bs
+++ b/spec.bs
@@ -439,13 +439,21 @@ A [=/request=] has an associated <dfn for=request>private token issuers</dfn>, w
 
 Note: [=request/Private token refresh policy=] is ignored unless [=request/private token operation=] is <code>"token-redemption"</code>. [=request/Private token issuers=] is ignored unless [=request/private token operation=] is <code>"send-redemption-record"</code>. [=request/Private token issuers=] must be specified and non-empty when [=request/private token operation=] is <code>"send-redemption-record"</code>.
 
+This specification defines two new [=policy-controlled features=]. Exactly one of these policy features applies for a given Private State Token operation.
+
+Policy identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-issuance</code></dfn>" applies for the <code>"token-request"</code> operation. The [=default allowlist=] for this feature is <code>["self"]</code>.
+
+Policy identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-redemption</code></dfn>" applies for the <code>"send-redemption-record"</code> and <code>"token-redemption"</code> operations. The [=default allowlist=] for this feature is <code>["self"]</code>.
+
 A [=request=] has an associated <dfn for="request">pstPretokens</dfn>, which is null or a [=byte sequence=].
 
 Add the following steps to the <code><a constructor lt="Request()">new Request (<var ignore>input</var>, |init|)</a></code> constructor, before step 28 ("<code>Set [=this=]'s [=Request/request=] to |request|</code>"):
 
  1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
      1. Set <var ignore>request</var>'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
-     1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>, then abort these steps.
+     1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
+         1. If [=should request be allowed to use feature=] for [=policy-controlled feature/private-state-token-issuance=] returns false, then abort these steps.
+     1. If [=should request be allowed to use feature=] for [=policy-controlled feature/private-state-token-redemption=] returns false, then abort these steps.
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
          1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
          1. Abort the remaining steps.

--- a/spec.bs
+++ b/spec.bs
@@ -443,7 +443,7 @@ This specification defines two new [=policy-controlled features=]. Exactly one o
 
 The [=policy-controlled feature=] identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-issuance</code></dfn>" applies for the <code>"token-request"</code> operation. The [=default allowlist=] for this feature is <code>["self"]</code>.
 
-Policy identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-redemption</code></dfn>" applies for the <code>"send-redemption-record"</code> and <code>"token-redemption"</code> operations. The [=default allowlist=] for this feature is <code>["self"]</code>.
+The [=policy-controlled feature=] identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-redemption</code></dfn>" applies for the <code>"send-redemption-record"</code> and <code>"token-redemption"</code> operations. The [=default allowlist=] for this feature is <code>["self"]</code>.
 
 A [=request=] has an associated <dfn for="request">pstPretokens</dfn>, which is null or a [=byte sequence=].
 

--- a/spec.bs
+++ b/spec.bs
@@ -379,7 +379,7 @@ To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |in
 1. Set |document| to |window|’s [=associated Document=].
 1. Let |origin| be |request|’s origin.
 1. Set |request|'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
-1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
+1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is {{OperationType/"token-request"}}:
     1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
     1. Abort the remaining steps.
 1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.

--- a/spec.bs
+++ b/spec.bs
@@ -452,8 +452,8 @@ Add the following steps to the <code><a constructor lt="Request()">new Request (
  1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
      1. Set <var ignore>request</var>'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
-         1. If [$Should request be allowed to use feature?$] for "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
-     1. If [$Should request be allowed to use feature?$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
+         1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
+     1. If [$Should request be allowed to use feature?|should request be allowed$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
          1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
          1. Abort the remaining steps.

--- a/spec.bs
+++ b/spec.bs
@@ -452,8 +452,8 @@ Add the following steps to the <code><a constructor lt="Request()">new Request (
  1. If |init|["{{RequestInit/privateToken}}"] [=map/exists=]:
      1. Set <var ignore>request</var>'s [=request/private token operation=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"].
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-request"</code>:
-         1. If [=should request be allowed to use feature=] for [=policy-controlled feature/private-state-token-issuance=] returns false, then abort these steps.
-     1. If [=should request be allowed to use feature=] for [=policy-controlled feature/private-state-token-redemption=] returns false, then abort these steps.
+         1. If [$Should request be allowed to use feature?$] for "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
+     1. If [$Should request be allowed to use feature?$] for "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" returns false, then throw  "{{NotAllowedError}}" {{DOMException}} and abort the remaining steps.
      1. If |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
          1. Set <var ignore>request</var>'s [=request/private token refresh policy=]</a> to |init|["{{RequestInit/privateToken}}"]["{{PrivateToken/refreshPolicy}}"].
          1. Abort the remaining steps.


### PR DESCRIPTION
Add permission policy feature definitions. 

Update the Request constructor with policy checks in Modifications to request section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aykutbulut/trust-token-api/pull/239.html" title="Last updated on May 8, 2023, 6:12 PM UTC (9916391)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/239/9927f3c...aykutbulut:9916391.html" title="Last updated on May 8, 2023, 6:12 PM UTC (9916391)">Diff</a>