### PR TITLE
Remove "type" from API.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -388,15 +388,8 @@ new one.
 enum RefreshPolicy { "none", "refresh" };
 </pre>
 
-The {{TokenType}} is currently set to `"private-state-token"`, as this is the only token
-type that the specification supports at this time.
-
-<pre class=idl>
-enum TokenType { "private-state-token" };
-</pre>
-
-The {{TokenVersion}} is currently set to `1`, as this is the only `"private-state-token"`
-version that the specification supports at this time.
+The {{TokenVersion}} is currently set to `1`, as this is the only version that the
+specification supports at this time.
 
 <pre class=idl>
 enum TokenVersion { "1" };
@@ -412,7 +405,6 @@ The {{PrivateToken}} contains the information required to make a fetch request.
 
 <pre class=idl>
 dictionary PrivateToken {
-  required TokenType type;
   required TokenVersion version;
   required OperationType operation;
   RefreshPolicy refreshPolicy = "none";
@@ -502,7 +494,6 @@ An issue request is created and fetched as demonstrated in the following snippet
 ```javascript
 let issueRequest = new Request("https://example.issuer:1234/issuer_path", {
   privateToken: {
-    type: "private-state-token",
     version: 1,
     operation: "token-request",
   }
@@ -608,7 +599,6 @@ snippet. The default value for refreshPolicy is `'none'`.
 ```javascript
 let redemptionRequest = new Request('https://example.issuer:1234/redemption_path', {
   privateToken: {
-    type: 'private-state-token',
     version: 1,
     operation: 'token-redemption',
     refreshPolicy: {'none', 'refresh'}
@@ -722,8 +712,8 @@ To <dfn>append private state token redemption record headers</dfn> given a [=/re
 
 <pre class="idl">
 partial interface Document {
-  Promise&lt;boolean> hasPrivateTokens(USVString issuer, USVString type);
-  Promise&lt;boolean> hasRedemptionRecord(USVString issuer, USVString type);
+  Promise&lt;boolean> hasPrivateTokens(USVString issuer);
+  Promise&lt;boolean> hasRedemptionRecord(USVString issuer);
 };
 </pre>
 
@@ -733,12 +723,11 @@ Query APIs {#query-apis}
 Token Query {#token-query}
 --------------------------
 
-When invoked on {{Document}} |doc| with {{USVString}} |issuer| and {{USVString}} |type|, the <dfn export method for=Document><code>hasPrivateTokens(issuer, type)</code></dfn> method must run these steps:
+When invoked on {{Document}} |doc| with {{USVString}} |issuer|, the <dfn export method for=Document><code>hasPrivateTokens(issuer)</code></dfn> method must run these steps:
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |type| is not `"private-state-token"`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |issuer|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |origin| be |parsedURL|'s [=/origin=].
@@ -760,13 +749,12 @@ user has tokens from. Note that querying tokens triggers removal of stale tokens
 Redemption Record Query {#redemption-record-query}
 --------------------------------------------------
 
-When invoked on {{Document}} |doc| with {{USVString}} |issuer| and {{USVString}} |type|, the <dfn export method for=Document><code>hasRedemptionRecord(issuer, type)</code></dfn> method must run these steps:
+When invoked on {{Document}} |doc| with {{USVString}} |issuer|, the <dfn export method for=Document><code>hasRedemptionRecord(issuer)</code></dfn> method must run these steps:
 
 1. Let |p| be [=a new promise=].
 1. If |doc| is not [=Document/fully active=], then [=reject=] |p| with an "{{InvalidStateError}}" {{DOMException}} and return |p|.
 1. Let |global| be |doc|'s [=relevant global object=].
 1. If |global| is not a [=secure context=], then [=reject=] |p| with a "{{NotAllowedError}}" {{DOMException}} and return |p|.
-1. If |type| is not `"private-state-token"`, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |parsedURL| be the the result of running the [=URL parser=] on |issuer|.
 1. If |parsedURL| is failure, [=reject=] |p| with a "{{TypeError}}" {{DOMException}} and return |p|.
 1. Let |origin| be |parsedURL|'s [=/origin=].


### PR DESCRIPTION
This removes "type" from the API until it is needed, resolving #222 and reducing the versioning to "version" to resolve #224.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/pull/241.html" title="Last updated on May 3, 2023, 1:46 PM UTC (8572ed6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/241/43a56f6...8572ed6.html" title="Last updated on May 3, 2023, 1:46 PM UTC (8572ed6)">Diff</a>