### PR TITLE
Add media type for key commitments.

### DIFF
--- a/ISSUER_PROTOCOL.md
+++ b/ISSUER_PROTOCOL.md
@@ -12,7 +12,7 @@ This section describes the public issuer interfaces that an issuer will need to 
 
 ### Issuer Key Commitments
 
-A Private State Token issuer should have an endpoint at a publicly accessible secure URL (HTTPS) that serves the current key commitments used in the Private State Token protocol. Requests to this endpoint should result in a JSON response of the following format:
+A Private State Token issuer should have an endpoint at a publicly accessible secure URL (HTTPS) that serves the current key commitments used in the Private State Token protocol. Requests to this endpoint should result in a JSON response with a media type of "application/token-issuer-directory" and content in the following format:
 
 
 ```

--- a/spec.bs
+++ b/spec.bs
@@ -31,19 +31,19 @@ urlPrefix: https://fetch.spec.whatwg.org/; spec: Fetch
 {
     "PRIVACY-PASS-ARCHITECTURE": {
         "authors": ["A. Davidson", "J. Iyengar", "C. A. Wood"],
-        "href": "https://www.ietf.org/archive/id/draft-ietf-privacypass-architecture-06.html",
+        "href": "https://www.ietf.org/archive/id/draft-ietf-privacypass-architecture-10.html",
         "publisher": "IETF",
         "title": "Privacy Pass Architectural Framework"
     },
     "PRIVACY-PASS-AUTH-SCHEME": {
         "authors": ["T. Pauly", "S. Valdez", "C. A. Wood"],
-        "href" : "https://www.ietf.org/archive/id/draft-ietf-privacypass-auth-scheme-05.html",
+        "href" : "https://www.ietf.org/archive/id/draft-ietf-privacypass-auth-scheme-10.html",
         "publisher": "IETF",
         "title": "The Privacy Pass HTTP Authentication Scheme"
     },
     "PRIVACY-PASS-ISSUANCE-PROTOCOL": {
         "authors": ["S. Celi", "A. Davidson", "A. Faz-Hernandez", "S. Valdez", "C. A. Wood"],
-        "href": "https://www.ietf.org/archive/id/draft-ietf-privacypass-protocol-06.html",
+        "href": "https://www.ietf.org/archive/id/draft-ietf-privacypass-protocol-10.html",
         "publisher": "IETF",
         "title": "Privacy Pass Issuance Protocol"
     },
@@ -179,7 +179,9 @@ the issuance and redemption operations.
 
 
 Requests to key commitment endpoints should result in a JSON response
-[[!RFC8259]] of the following format.
+[[!RFC8259]] of the following format with a media type of
+`"application/token-issuer-directory`" (using the media type defined in
+[[!PRIVACY-PASS-ISSUANCE-PROTOCOL]]):
 
 ```javascript
 {

--- a/spec.bs
+++ b/spec.bs
@@ -180,7 +180,7 @@ the issuance and redemption operations.
 
 Requests to key commitment endpoints should result in a JSON response
 [[!RFC8259]] of the following format with a media type of
-`"application/token-issuer-directory`" (using the media type defined in
+`"application/token-issuer-directory"` (using the media type defined in
 [[!PRIVACY-PASS-ISSUANCE-PROTOCOL]]):
 
 ```javascript


### PR DESCRIPTION
This fixes #232.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/pull/247.html" title="Last updated on May 18, 2023, 8:34 PM UTC (17e4289)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/247/c078408...17e4289.html" title="Last updated on May 18, 2023, 8:34 PM UTC (17e4289)">Diff</a>