### PR TITLE
Refer to right request

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -376,7 +376,7 @@ To <dfn>unmask tokens</dfn> given [=key commitments=] |issuerKeys|, byte string 
 1. Let |result| ([=list=] of byte strings) be the result of running |unmaskOperation| on |pretokens| and |response|.
 1. Return |result|.
 
-To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |input|, a {{RequestInit}} |init| and a {{Request}} |request| run the following steps:
+To <dfn>set private token property for request</dfn> given a {{RequestInfo}} |input|, a {{RequestInit}} |init| and a [=request=] |request| run the following steps:
 1. Let |window| be |request|’s [=request/window=].
 1. Let |document| be |window|’s [=associated Document=].
 1. Let |origin| be |request|’s origin.


### PR DESCRIPTION
Refer to right request in "set private token properties for request" algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aykutbulut/trust-token-api/pull/267.html" title="Last updated on Jul 12, 2023, 2:19 AM UTC (1779d18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/267/eb68759...aykutbulut:1779d18.html" title="Last updated on Jul 12, 2023, 2:19 AM UTC (1779d18)">Diff</a>