### PR TITLE
Update permission policy check

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -376,16 +376,14 @@ To <dfn>unmask tokens</dfn> given [=key commitments=] |issuerKeys|, byte string 
 1. Let |result| ([=list=] of byte strings) be the result of running |unmaskOperation| on |pretokens| and |response|.
 1. Return |result|.
 
-To <dfn>set private token properties for request from private token</dfn>, given a {{PrivateToken}} |privateToken| and a {{Request}} |request|, run the following steps:
-1. Let |window| be |request|’s [=request/window=].
-1. Let |document| be |window|’s [=associated Document=].
-1. Let |origin| be |request|’s [=/origin=].
+To <dfn>set private token properties for request from private token</dfn>, given a {{PrivateToken}} |privateToken| and a [=request=] |request|, run the following steps:
+
 1. Set |request|'s [=request/private token operation=]</a> to |privateToken|["{{PrivateToken/operation}}"].
 1. If |privateToken|["{{PrivateToken/operation}}"] is {{OperationType/"token-request"}}:
-    1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
+    1. If [$Should request be allowed to use feature?|should request be allowed to use feature$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.
     1. Abort the remaining steps.
 1. Assert: |privateToken|["{{PrivateToken/operation}}"] is {{OperationType/"token-redemption"}} or {{OperationType/"send-redemption-record"}}.
-1. If [$Is feature enabled in document for origin?|is feature enabled$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>", |document| and |origin| returns `"Disabled"`, then throw a "{{NotAllowedError}}" {{DOMException}}.
+1. If [$Should request be allowed to use feature?|should request be allowed to use feature$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.
 1. If |privateToken|["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
     1. Set |request|'s [=request/private token refresh policy=]</a> to |privateToken|["{{PrivateToken/refreshPolicy}}"].
     1. Abort the remaining steps.
@@ -533,7 +531,7 @@ After the step:
 
 Add the step:
 
-1. Run [=set private token properties for request from private token=] with |req| and <a>this</a>'s [=XMLHttpRequest/private state token=].
+1. Run [=set private token properties for request from private token=] with <a>this</a>'s [=XMLHttpRequest/private state token=] and |req|.
 
 Issuing Protocol {#issuing-protocol}
 ====================================

--- a/spec.bs
+++ b/spec.bs
@@ -380,7 +380,7 @@ To <dfn>set private token properties for request from private token</dfn>, given
 
 1. Set |request|'s [=request/private token operation=]</a> to |privateToken|["{{PrivateToken/operation}}"].
 1. If |privateToken|["{{PrivateToken/operation}}"] is {{OperationType/"token-request"}}:
-    1. If [$Should request be allowed to use feature?|should request be allowed to use feature$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.
+    1. If [$Should request be allowed to use feature?$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.
     1. Abort the remaining steps.
 1. Assert: |privateToken|["{{PrivateToken/operation}}"] is {{OperationType/"token-redemption"}} or {{OperationType/"send-redemption-record"}}.
 1. If [$Should request be allowed to use feature?|should request be allowed to use feature$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.

--- a/spec.bs
+++ b/spec.bs
@@ -383,7 +383,7 @@ To <dfn>set private token properties for request from private token</dfn>, given
     1. If [$Should request be allowed to use feature?$] on "<code>[=policy-controlled feature/private-state-token-issuance=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.
     1. Abort the remaining steps.
 1. Assert: |privateToken|["{{PrivateToken/operation}}"] is {{OperationType/"token-redemption"}} or {{OperationType/"send-redemption-record"}}.
-1. If [$Should request be allowed to use feature?|should request be allowed to use feature$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.
+1. If [$Should request be allowed to use feature?$] on "<code>[=policy-controlled feature/private-state-token-redemption=]</code>" and |request| returns <code>false</code>, then throw a "{{NotAllowedError}}" {{DOMException}}.
 1. If |privateToken|["{{PrivateToken/operation}}"] is <code>"token-redemption"</code>:
     1. Set |request|'s [=request/private token refresh policy=]</a> to |privateToken|["{{PrivateToken/refreshPolicy}}"].
     1. Abort the remaining steps.


### PR DESCRIPTION
Use "Should request be allowed to use feature?" algorithm instead of "Is feature enabled in document for origin?". The former requires only a policy feature and a request. This simplifies things.

Change the order of the arguments for "set private token properties for request from private token" in XHR section.

Fixes #269.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aykutbulut/trust-token-api/pull/270.html" title="Last updated on Jul 13, 2023, 7:47 PM UTC (7dd9350)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/270/1756871...aykutbulut:7dd9350.html" title="Last updated on Jul 13, 2023, 7:47 PM UTC (7dd9350)">Diff</a>