### PR TITLE
Drop non-standard "Reflect" extended attribute

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -507,7 +507,7 @@ The <{iframe}> element contains a <dfn element-attr for="iframe">privateToken</d
 
   <pre class=idl>
   partial interface HTMLIFrameElement {
-    [SecureContext, Reflect] attribute DOMString privateToken;
+    [SecureContext] attribute DOMString privateToken;
   };
   </pre>
 


### PR DESCRIPTION
PR #266 introduced the `privateToken` attribute on `iframe`. The attribute was flagged with a `Reflect` extended attribute to indicate that it reflects the `privateToken` content attribute (already specified in prose). While this attribute is understood by some browser code bases, it is not a standard one, and not defined Web IDL in particular.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/trust-token-api/pull/271.html" title="Last updated on Jul 14, 2023, 7:07 AM UTC (ef5e0b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/271/6596d23...tidoust:ef5e0b1.html" title="Last updated on Jul 14, 2023, 7:07 AM UTC (ef5e0b1)">Diff</a>