### PR TITLE
Remove incorrect field from IssueResponse.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -280,7 +280,6 @@ struct {
 } IssueRequest;
 
 struct {
-  ECPoint blinded; // Note: We diverge from the BlindEvaluateBatch specification by including this field along with each evaluatedElement.
   ECPoint evaluated; // Corresponding to evaluatedElements
 } SignedNonce;
 


### PR DESCRIPTION
In the current implementation, we don't diverge from the batched spec and don't include the blinded element in the IssueResponse.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/pull/295.html" title="Last updated on Mar 27, 2024, 4:08 PM UTC (db917ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/295/cb60720...db917ec.html" title="Last updated on Mar 27, 2024, 4:08 PM UTC (db917ec)">Diff</a>