### PR TITLE
Corrected a tipo in retrieve redemption record algorithm.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -405,8 +405,8 @@ To <dfn>record a redemption record</dfn> given an [=/origin=] |issuer|, an [=/or
 To <dfn>retrieve a redemption record</dfn> given an [=/origin=] |issuer| and an [=/origin=] |topLevel|, run the following steps:
 
 1. Let |currentTime| be the current date and time in milliseconds since 01 January, 1970 UTC.
-1. If [=redemptionTimes=][(|issuer|,|topLevel|)] [=map/exists|does not exist=], return null.
-1. Let (|record|, |expiration|, |signingKeys|) be [=redemptionTimes=][(|issuer|,|topLevel|)].
+1. If [=redemptionRecords=][(|issuer|,|topLevel|)] [=map/exists|does not exist=], return null.
+1. Let (|record|, |expiration|, |signingKeys|) be [=redemptionRecords=][(|issuer|,|topLevel|)].
 1. If |expiration| is less than |currentTime|, return null.
 1. Let |currentSigningKeys| be the result of [=look up the latest keys|looking up of the latest keys=] for |issuer|.
 1. If |currentSigningKeys| does not equal |signingKeys|, return null.


### PR DESCRIPTION
Replaced redemptionTimes map with redemptionRecords.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cooleck/trust-token-api/pull/300.html" title="Last updated on Jun 8, 2024, 2:36 PM UTC (4c6ca08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/300/00dd7af...cooleck:4c6ca08.html" title="Last updated on Jun 8, 2024, 2:36 PM UTC (4c6ca08)">Diff</a>