### PR TITLE
Consider making permission defaults * instead of self

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -580,9 +580,9 @@ Note: [=request/Private token refresh policy=] is ignored unless [=request/priva
 
 This specification defines two new [=policy-controlled features=]. Exactly one of these policy features applies for a given Private State Token operation.
 
-The [=policy-controlled feature=] identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-issuance</code></dfn>" applies for the <code>"token-request"</code> operation. The [=default allowlist=] for this feature is <code>["self"]</code>.
+The [=policy-controlled feature=] identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-issuance</code></dfn>" applies for the <code>"token-request"</code> operation. The [=default allowlist=] for this feature is <code>*</code>.
 
-The [=policy-controlled feature=] identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-redemption</code></dfn>" applies for the <code>"send-redemption-record"</code> and <code>"token-redemption"</code> operations. The [=default allowlist=] for this feature is <code>["self"]</code>.
+The [=policy-controlled feature=] identified by "<dfn data-dfn-for="policy-controlled feature"><code>private-state-token-redemption</code></dfn>" applies for the <code>"send-redemption-record"</code> and <code>"token-redemption"</code> operations. The [=default allowlist=] for this feature is <code>*</code>.
 
 A [=request=] has an associated <dfn for="request">pstPretokens</dfn>, which is null or a [=byte sequence=].
 


### PR DESCRIPTION
Not asking for review of this yet, but posting here for consideration as part of #106


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/arichiv/trust-token-api/pull/304.html" title="Last updated on Jul 17, 2024, 7:44 PM UTC (5356c76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/trust-token-api/304/ae07cb5...arichiv:5356c76.html" title="Last updated on Jul 17, 2024, 7:44 PM UTC (5356c76)">Diff</a>